### PR TITLE
Make pattern matching more accurate

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -121,8 +121,8 @@ process fastqc_readqc{
   """
 }
 
-forward = Channel.fromPath("${params.input}/*1*.{fastq.gz,fsa.gz,fa.gz,fastq,fsa,fa}")
-reverse = Channel.fromPath("${params.input}/*2*.{fastq.gz,fsa.gz,fa.gz,fastq,fsa,fa}")
+forward = Channel.fromPath("${params.input}/*_R1_*.{fastq.gz,fsa.gz,fa.gz,fastq,fsa,fa}")
+reverse = Channel.fromPath("${params.input}/*_R2_*.{fastq.gz,fsa.gz,fa.gz,fastq,fsa,fa}")
 
 
 process lane_concatination{


### PR DESCRIPTION
# Description
Make the pattern to match more specifically forward and reverse reads when the file names may contain numbers 1 and 2 in more than one place. Fixes Issue #31.

_Summary of the changes made:_
Changed pattern matching from `*1*` and `*2*` to `*_R1_*` and `*_R2_*`.

## Primary function of PR
- [x] Hotfix
- [ ] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality
