### PR TITLE
Exits and more in deploy_references.sh and deploy_conda.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ JASEN has been tested using MRSA, but should work well with any bacteria with a 
 ### Recommended
 * Conda
 * Singularity Remote Login
-
+* mamba, Is available from conda. Install in base environment.
 ## Development deployment (self-contained)
 * `git clone --recurse-submodules --single-branch --branch master  https://github.com/genomic-medicine-sweden/JASEN.git && cd JASEN # Copies code locally`
 * `bash -i deploy/deploy_conda.sh # Creates development environment`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ JASEN has been tested using MRSA, but should work well with any bacteria with a 
 ### Recommended
 * Conda
 * Singularity Remote Login
-* mamba, Is available from conda. Install in base environment.
+* Mamba. Is available from conda. Install in base environment.
 ## Development deployment (self-contained)
 * `git clone --recurse-submodules --single-branch --branch master  https://github.com/genomic-medicine-sweden/JASEN.git && cd JASEN # Copies code locally`
 * `bash -i deploy/deploy_conda.sh # Creates development environment`

--- a/deploy/deploy_conda.sh
+++ b/deploy/deploy_conda.sh
@@ -1,23 +1,34 @@
 #!/usr/bin/env bash
 
+# quit script if any of the commands fails. Note that && commands should be in paranthesis for this to work.
+set -eox pipefail
+trap 'exit_status="$?" && echo Failed on line: $LINENO at command: $BASH_COMMAND && echo "exit status $exit_status" && exit' ERR
+
+# name for the conda environment. Should be possible to create another name instead of jasen.
 NAME=$1
+# script directory
 scriptdir="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
+# If the user did not gave a name for the conda environment on the command line, then the name will be jasen
 if ! [ $NAME ]; then
    NAME=jasen
-fi   
+fi
 
+conda info
+#Unload environment. Deactivation not working properly.
+conda info | grep -q $NAME && conda deactivate || :
+conda info
 
-#Unload environment
-conda info | grep -q $NAME && source deactivate || :
 #Remove environment if already present
 echo "Purging any duplicate existing environment"
 conda remove -y -n $NAME --all || :
 
 echo "Creating JASEN environment named $NAME"
 #conda create --name $NAME -f $scriptdir/reqs/reqs.txt -q 
-conda env create -f deploy/reqs/env-index-mini.yaml 
+# mamba is used for quicker env resolve time
+mamba env create -f deploy/reqs/env-index-mini.yaml 
 source activate jasen
+conda info
 cd $scriptdir/../bin/pipeline_result_processor
 pip install .
 cd $scriptdir

--- a/deploy/deploy_conda.sh
+++ b/deploy/deploy_conda.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # quit script if any of the commands fails. Note that && commands should be in paranthesis for this to work.
-set -eox pipefail
+set -eo pipefail
 trap 'exit_status="$?" && echo Failed on line: $LINENO at command: $BASH_COMMAND && echo "exit status $exit_status" && exit' ERR
 
 # name for the conda environment. Should be possible to create another name instead of jasen.
@@ -27,6 +27,7 @@ echo "Creating JASEN environment named $NAME"
 #conda create --name $NAME -f $scriptdir/reqs/reqs.txt -q 
 # mamba is used for quicker env resolve time
 mamba env create -f deploy/reqs/env-index-mini.yaml 
+echo "stopped here"
 source activate jasen
 conda info
 cd $scriptdir/../bin/pipeline_result_processor

--- a/deploy/deploy_references.sh
+++ b/deploy/deploy_references.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-# quit script if any of the commands fails. Note that && commands should be in paranthesis for this to work.
+# quit script if any of the commands fails. Note that && commands will get an error but the script 
+# will continue UNLESS you use a paranthesis e.g., (echo hey && echo hey2) .
 set -eo pipefail
 trap 'exit_status="$?" && echo Failed on line: $LINENO at command: $BASH_COMMAND && echo "exit status $exit_status" && exit' ERR
-
-
 
 mkdir assets &> /dev/null
 mkdir assets/genomes &> /dev/null

--- a/deploy/deploy_references.sh
+++ b/deploy/deploy_references.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-# Exit script and throw exception if any of the commands fail
-set -e
+# quit script if any of the commands fails. Note that && commands should be in paranthesis for this to work.
+set -eo pipefail
+trap 'exit_status="$?" && echo Failed on line: $LINENO at command: $BASH_COMMAND && echo "exit status $exit_status" && exit' ERR
+
+
 
 mkdir assets &> /dev/null
 mkdir assets/genomes &> /dev/null

--- a/deploy/deploy_references.sh
+++ b/deploy/deploy_references.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Exit script and throw exception if any of the commands fail
+set -e
+
 mkdir assets &> /dev/null
 mkdir assets/genomes &> /dev/null
 mkdir assets/card &> /dev/null

--- a/deploy/deploy_references.sh
+++ b/deploy/deploy_references.sh
@@ -5,11 +5,11 @@
 set -eo pipefail
 trap 'exit_status="$?" && echo Failed on line: $LINENO at command: $BASH_COMMAND && echo "exit status $exit_status" && exit' ERR
 
-mkdir assets &> /dev/null
-mkdir assets/genomes &> /dev/null
-mkdir assets/card &> /dev/null
-mkdir assets/cgmlst &> /dev/null
-mkdir assets/blast &> /dev/null
+mkdir -p assets &> /dev/null
+mkdir -p assets/genomes &> /dev/null
+mkdir -p assets/card &> /dev/null
+mkdir -p assets/cgmlst &> /dev/null
+mkdir -p assets/blast &> /dev/null
 
 scriptdir="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 assdir="${scriptdir}/../assets/"

--- a/deploy/reqs/env-index-mini.yaml
+++ b/deploy/reqs/env-index-mini.yaml
@@ -1,6 +1,5 @@
 name: jasen
 channels:
-  - anaconda
   - bioconda
   - conda-forge
   - defaults


### PR DESCRIPTION
# Description


_What prompted the change?_
There were no good exits/error messages. 
Some minor changes were needed.
Mamba should be used.

_Summary of the changes made:_
Added some code for quiting script if there is a commands that fails in deploy_references.sh and deploy_conda.sh.
Removed anaconda as channel in requirements as it does not seem to be needed with env-index-mini.yaml.
Changed deplooy_conda.sh to use mamba instead of conda as this improves/solves the "solving environment"-issue. 
Added -p-flags to deploy-references.sh so that directories as created as needed. 

## Primary function of PR
- [ ] Hotfix
- [x] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality

# Testing
_Either describe a procedure, or add data; that confirms that the PR resolves what it sets out to do_

# Sign-offs
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
