### PR TITLE
Update chewBBACA and batch list submission for HPC issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ work/
 .nextflow/
 .nextflow*
 assets/references
+assets/blast
+assets/card
+assets/cgmlst
+assets/genomes
 work/
 results
 container/*.sif

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ JASEN has been tested using MRSA, but should work well with any bacteria with a 
 * `(Optional) singularity remote login # Access to OCI regestries`
 * `cd container && sudo bash -i build_container.sh && cd .. # Creates singularity images`
 * Edit the `root` parameter in `configs/nextflow.base.config`
+* Edit the read1 and read2 columns in `assets/test_data/samplelist.csv`
 
 ## Usage
 

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -2,29 +2,13 @@
 
 singularity{
   enabled = true
-  runOptions = '--bind /fs1/ --bind /local/'
+  runOptions = '--bind /fs1/ --bind /fs2/ --bind /local/'
 }
 
 process {
 	executor='slurm'
-	queue='grace-high'
+	queue='grace-normal'
 	time=2.h
-
-	withLabel: 'process_high' {
-		cpus = 4
-		memory = '16 GB'
-		time = '4h'
-	}
-	withLabel: 'process_medium' {
-		cpus = 2
-		memory = '8 GB'
-		time = '1h'
-	}
-	withLabel: 'process_low' {
-		cpus = 1
-		memory = '1 GB'
-		time = '1h'
-	}
 
 	withName: ariba_run {
 		container = "/fs1/pipelines/JASEN/container/ariba.sif"
@@ -69,8 +53,8 @@ process {
 		publishDir = "/fs1/results_dev/jasen/kraken"
 	}
 	withName: bracken {
-		cpus = 16
-		memory = '48 GB'
+		cpus = 4
+		memory = '12 GB'
 		time = '2h'
 		container = "/fs1/pipelines/JASEN/container/bracken.sif"
 		publishDir = "/fs1/results_dev/jasen/kraken"
@@ -125,7 +109,7 @@ params {
 	mlstBlastDb = "${root}/assets/blast/mlst.fa"
 	//krakenDb = "/fs1/resources/ref/micro/krakenstd"
 	// INPUT & OUTPUT //
-	localTempDir = "/tmp"
+	localTempDir = "/local/scratch"
 	workDir = "/fs1/ryan/pipelines/jasen/wd"
 	publishDir = ""
 	publishDirMode = ""

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -1,0 +1,170 @@
+// Hopper specific configuration for micro wgs pipeline //
+
+singularity{
+  enabled = true
+  runOptions = '--bind /fs1/ --bind /local/'
+}
+
+process {
+	executor='slurm'
+	queue='grace-high'
+	time=2.h
+
+	withLabel: 'process_high' {
+		cpus = 4
+		memory = '16 GB'
+		time = '4h'
+	}
+	withLabel: 'process_medium' {
+		cpus = 2
+		memory = '8 GB'
+		time = '1h'
+	}
+	withLabel: 'process_low' {
+		cpus = 1
+		memory = '1 GB'
+		time = '1h'
+	}
+
+	withName: ariba_run {
+		container = "/fs1/pipelines/JASEN/container/ariba.sif"
+		memory = '32 GB'
+		publishDir = "/fs1/results_dev/jasen/ariba"
+	}
+	withName: ariba_summary {
+		container = "/fs1/pipelines/JASEN/container/ariba.sif"
+		publishDir = "/fs1/results_dev/jasen/ariba"
+	}
+	withName: 'bwa_mem|bwa_index' {
+		container = "/fs1/pipelines/JASEN/container/bwa.sif"
+		cpus = 16
+		memory = '32 GB'
+		time = '1h'
+		publishDir = "/fs1/results_dev/jasen/bwa"
+	}
+	withName: 'samtools_sort|samtools_index' {
+		container = "/fs1/pipelines/JASEN/container/samtools.sif"
+		publishDir = "/fs1/results_dev/jasen/samtools"
+	}
+	withName: spades {
+		container = "/fs1/pipelines/JASEN/container/spades.sif"
+		cpus = 16
+		memory = '64 GB'
+		time = '2h'
+		publishDir = "/fs1/results_dev/jasen/spades"
+	}
+	withName: quast {
+		container = "/fs1/pipelines/JASEN/container/quast.sif"
+		publishDir = "/fs1/results_dev/jasen/quast"
+	}
+	withName: mlst {
+		container = "/fs1/pipelines/JASEN/container/mlst.sif"
+		publishDir = "/fs1/results_dev/jasen/mlst"
+	}
+	withName: kraken {
+		cpus = 16
+		memory = '48 GB'
+		time = '2h'
+		container = "/fs1/pipelines/JASEN/container/kraken2.sif"
+		publishDir = "/fs1/results_dev/jasen/kraken"
+	}
+	withName: bracken {
+		cpus = 16
+		memory = '48 GB'
+		time = '2h'
+		container = "/fs1/pipelines/JASEN/container/bracken.sif"
+		publishDir = "/fs1/results_dev/jasen/kraken"
+	}
+	withName: resfinder {
+		container = "/fs1/pipelines/JASEN/container/resfinder.sif"
+		publishDir = "/fs1/results_dev/jasen/resfinder"
+	}
+	withName: virulencefinder {
+		container = "/fs1/pipelines/JASEN/container/virulencefinder.sif"
+		publishDir = "/fs1/results_dev/jasen/virulencefinder"
+	}
+	withName: freebayes {
+		container = "/fs1/pipelines/JASEN/container/freebayes.sif"
+		publishDir = "/fs1/results_dev/jasen/freebayes"
+	}
+	withName: 'chewbbaca_allelecall|chewbbaca_split_results|chewbbaca_split_missing_loci|chewbbaca_create_batch_list' {
+		//executor='local'
+		container = "/fs1/pipelines/JASEN/container/chewbbaca_3.1.0.sif"
+		cpus = 7
+		publishDir = "/fs1/results_dev/jasen/chewbbaca"
+	}
+	withName: ariba_summary_to_json {
+		container = "/fs1/pipelines/JASEN/container/perl_json_3A4.02.sif"
+		publishDir = "/fs1/results_dev/jasen/ariba"
+	}
+	withName: post_align_qc {
+		container = "/fs1/pipelines/JASEN/container/postAlignQc.sif"
+		publishDir = "/fs1/results_dev/jasen/postalignqc"
+	}
+	withName: export_to_cdm {
+		publishDir = "/fs1/results_dev/cron/qc"
+	}
+	withName: create_analysis_result {
+		container = "/fs1/pipelines/JASEN/container/pythonScripts.sif"
+		publishDir = "/fs1/results_dev/jasen/analysis_result"
+	}
+	withName: save_analysis_metadata {
+		publishDir = "/fs1/results_dev/jasen/analysis_metadata"
+	}
+	withName: 'mask_polymorph_assembly' {
+		publishDir = "/fs1/results_dev/jasen/misc"
+	}
+}
+
+params {
+	root = "/fs1/pipelines/JASEN"
+	// DATABASES //
+	resfinderDb = "${root}/assets/resfinder_db"
+	pointfinderDb = "${root}/assets/pointfinder_db"
+	virulencefinderDb = "${root}/assets/virulencefinder_db"
+	mlstBlastDb = "${root}/assets/blast/mlst.fa"
+	//krakenDb = "/fs1/resources/ref/micro/krakenstd"
+	// INPUT & OUTPUT //
+	localTempDir = "/tmp"
+	workDir = "/fs1/ryan/pipelines/jasen/wd"
+	publishDir = ""
+	publishDirMode = ""
+	publishDirOverwrite = true
+	outdir = ""
+	args = ""
+	prefix = ""
+	// PIPELINE OPTIONS //
+	strands = 2
+	useKraken = false
+}
+
+profiles {
+	staphylococcus_aureus {
+		params.specie = "staphylococcus aureus"
+		params.genomeReference = "${params.root}/assets/genomes/CP000046.1.fasta"
+		params.aribaReference = "${params.root}/assets/card/nucleotide_fasta_protein_homolog_model.fasta"
+		params.cgmlstDb = "${params.root}/assets/cgmlst/staphylococcus_aureus/alleles_rereffed"
+		params.cgmlstSchema = "${params.root}/assets/cgmlst/staphylococcus_aureus/bed/CP000046.1.bed"
+		params.trainingFile = "${params.root}/assets/prodigal_training_files/Staphylococcus_aureus.trn"
+		params.useVirulenceDbs = ['s.aureus_hostimm', 's.aureus_exoenzyme', 's.aureus_toxin']
+	}
+
+	escherichia_coli {
+		params.specie = 'escherichia coli'
+		params.genomeReference = "${params.root}/assets/genomes/GCF_000008865.2.fasta"
+		params.aribaReference = "${params.root}/assets/card/nucleotide_fasta_protein_homolog_model.fasta"
+		params.cgmlstDb = "${params.root}/assets/cgmlst/escherichia_coli/alleles"
+		params.cgmlstSchema = "${params.root}/assets/cgmlst/escherichia_coli/bed"
+		params.trainingFile = "${params.root}/assets/prodigal_training_files/Escherichia_coli.trn"
+		params.useVirulenceDbs = ['virulence_ecoli']
+	}
+
+	klebsiella_pneumoniae {
+		params.specie = 'klebsiella pneumoniae'
+		params.genomeReference = "${params.root}/assets/genomes/NC_016845.1.fasta"
+		params.aribaReference = "${params.root}/assets/card/nucleotide_fasta_protein_homolog_model.fasta"
+		params.cgmlstDb = "${params.root}/assets/cgmlst/klebsiella_pneumoniae/alleles"
+		params.cgmlstSchema = "${params.root}/assets/cgmlst/klebsiella_pneumoniae/bed"
+		params.trainingFile = "${params.root}/assets/prodigal_training_files/Klebsiella_pneumoniae.trn"
+	}
+}

--- a/container/chewbbaca
+++ b/container/chewbbaca
@@ -1,5 +1,5 @@
 Bootstrap:docker
-From:condaforge/mambaforge:latest
+From:condaforge/mambaforge:22.9.0-3
 
 
 %labels

--- a/container/chewbbaca
+++ b/container/chewbbaca
@@ -1,32 +1,21 @@
 Bootstrap:docker
-From:python:3.7.11
+From:condaforge/mambaforge:latest
 
 
 %labels
-	MAINTAINER Björn Hallström <bjorn.hallstrom@skane.se>
+	MAINTAINER Ryan Kennedy <ryan.kennedy@skane.se>
 	DESCRIPTION Singularity container for CMD microbiology WGS pipeline
-	VERSION 2.8.5
+	VERSION 3.1.0
 
 %post
-     CHEWBBACA_VERSION=2.8.5
+     CHEWBBACA_VERSION=3.1.0
      BLAST_VERSION=2.9.0
      PRODIGAL_VERSION=2.6.3
-     MAFT_VERSION=7.480-1
-
-	 cd $HOME
-	 wget -O blast.tar.gz "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${BLAST_VERSION}/ncbi-blast-${BLAST_VERSION}+-x64-linux.tar.gz"
-	 tar -xzf blast.tar.gz
-	 cd "ncbi-blast-${BLAST_VERSION}+/bin/"
-	 chmod +x *
-	 cp * /usr/bin
-	 cd $HOME
-
-	 wget -O prodigal "https://github.com/hyattpd/Prodigal/releases/download/v${PRODIGAL_VERSION}/prodigal.linux"
-	 chmod +x prodigal
-	 cp prodigal /usr/bin
-
-	 wget -O maft.deb "https://mafft.cbrc.jp/alignment/software/mafft_${MAFT_VERSION}_amd64.deb"
-	 dpkg -i maft.deb
-
+     MAFFT_VERSION=7.505
+	 
+	 mamba install -c bioconda -c conda-forge numpy>=1.23.4 scipy>=1.9.3 biopython>=1.78 plotly>=5.8.0 SPARQLWrapper>=2.0.0 requests>=2.27.1 pandas>=1.5.1 BLAST>="${BLAST_VERSION}" Prodigal>="${PRODIGAL_VERSION}" MAFFT>="${MAFFT_VERSION}"
 	 pip install chewbbaca=="${CHEWBBACA_VERSION}"
-	 pip install utils chardet
+	 #pip install utils chardet
+
+%test
+     /opt/conda/bin/chewBBACA.py -V

--- a/main.nf
+++ b/main.nf
@@ -13,95 +13,15 @@ include { mlst } from './nextflow-modules/modules/mlst/main.nf' addParams( args:
 include { ariba_prepareref } from './nextflow-modules/modules/ariba/main.nf'
 include { ariba_run } from './nextflow-modules/modules/ariba/main.nf' addParams( args: ['--force'] )
 include { ariba_summary } from './nextflow-modules/modules/ariba/main.nf' addParams( args: ['--col_filter', 'n', '--row_filter', 'n'] )
+include { ariba_summary_to_json } from './nextflow-modules/modules/ariba/main.nf'
 include { kraken } from './nextflow-modules/modules/kraken/main.nf' addParams( args: ['--gzip-compressed'] )
 include { bracken } from './nextflow-modules/modules/bracken/main.nf' addParams( args: ['-r', '150'] )
 include { bwa_mem as bwa_mem_ref; bwa_mem as bwa_mem_dedup; bwa_index } from './nextflow-modules/modules/bwa/main.nf' addParams( args: ['-M'] )
+include { post_align_qc } from './nextflow-modules/modules/qc/main.nf'
 include { chewbbaca_allelecall; chewbbaca_split_results; chewbbaca_split_missing_loci; chewbbaca_create_batch_list} from './nextflow-modules/modules/chewbbaca/main.nf' addParams( args: [] )
 include { resfinder } from './nextflow-modules/modules/resfinder/main.nf' addParams( args: [] )
 include { virulencefinder } from './nextflow-modules/modules/virulencefinder/main.nf' addParams( args: [] )
-
-
-process ariba_summary_to_json {
-  tag "${sampleName}"
-  label "process_low"
-  publishDir params.publishDir, 
-    mode: params.publishDirMode, 
-    overwrite: params.publishDirOverwrite
-
-  input:
-    tuple val(sampleName), path(report), path(summary) 
-    path reference
-
-  output:
-    tuple val(sampleName), path("${output}"), emit: output
-
-  script:
-    output = "${summary.simpleName}_export.json"
-    """
-    ariba2json.pl ${reference} ${summary} ${report} > ${output}
-    """
-}
-
-process post_align_qc {
-  tag "${sampleName}"
-  label "process_low"
-  publishDir params.publishDir, 
-    mode: params.publishDirMode, 
-    overwrite: params.publishDirOverwrite
-
-  input:
-    tuple val(sampleName), path(bam)
-    path bai
-    path reference
-
-  output:
-    tuple val(sampleName), path(output)
-
-  script:
-    output = "${sampleName}_bwa.qc"
-    """
-    postaln_qc.pl ${bam} ${reference} ${sampleName} ${task.cpus} > ${output}
-    """
-}
-
-process create_analysis_result {
-  label "process_low"
-  tag "${sampleName}"
-  publishDir "${params.publishDir}", 
-    mode: params.publishDirMode, 
-    overwrite: params.publishDirOverwrite
-
-  input:
-    path runInfo
-    //paths
-    tuple val(sampleName), val(quast), val(mlst), val(cgmlst), val(resistance), val(resfinderMeta), val(virulence), val(virulencefinderMeta), val(bracken)
-
-  output:
-    path(output)
-
-  script:
-    output = "${sampleName}_result.json"
-    quastArgs = quast ? "--quast ${quast}" : "" 
-    brackenArgs = bracken ? "--kraken ${bracken}" : "" 
-    mlstArgs = mlst ? "--mlst ${mlst}" : "" 
-    cgmlstArgs = cgmlst ? "--cgmlst ${cgmlst}" : "" 
-    resfinderArgs = resistance ? "--resistance ${resistance}" : "" 
-    resfinderArgs = resfinderMeta ? "${resfinderArgs} --process-metadata ${resfinderMeta}" : resfinderArgs
-    virulenceArgs = virulence ? "--virulence ${virulence}" : "" 
-    virulenceArgs = virulencefinderMeta ? "${virulenceArgs} --process-metadata ${virulencefinderMeta}" : virulenceArgs
-    """
-    prp create-output \\
-      --sample-id ${sampleName} \\
-      --run-metadata ${runInfo} \\
-      ${quastArgs} \\
-      ${brackenArgs} \\
-      ${mlstArgs} \\
-      ${cgmlstArgs} \\
-      ${virulenceArgs} \\
-      ${resfinderArgs} \\
-      ${output}
-    """ 
-}
+include { create_analysis_result } from './nextflow-modules/modules/prp/main.nf' addParams( args: [] )
 
 workflow bacterial_default {
   if (params.strands==2){


### PR DESCRIPTION
# Description
When submitting multiple samples in parallel using an HPC, the following [issue](https://github.com/B-UMMI/chewBBACA/issues/11) regarding temp folders arises as parallel processes compete for the same databases at the same time. In order to solve this, the outputs from the step prior are collected to generate one batch file, which is fed into chewbbaca, and the output is split up thereafter. Furthermore, we updated the chewbacca singularity image to contain v3.1.0 from v2.8.5. We have also added our config file. 


## Primary function of PR
- [ ] Hotfix
- [x] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality

# Testing
The pipeline was tested on multiple samples ran in parallel without internet connection.

# Sign-offs
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
