### PR TITLE
Add skesa module

### DIFF
--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -53,6 +53,14 @@ process {
 		time = '2h'
 		publishDir = "/fs1/results_dev/jasen/spades"
 	}
+	withName: skesa {
+		container = "/fs1/pipelines/JASEN/container/skesa_2.4.0.sif"
+		cpus = 16
+		memory = '64 GB'
+		time = '2h'
+		publishDir = "/fs1/results_dev/jasen/skesa"
+		ext.args = "--cores 4 --memory 48"
+	}
 	withName: quast {
 		container = "/fs1/pipelines/JASEN/container/quast.sif"
 		publishDir = "/fs1/results_dev/jasen/quast"
@@ -136,6 +144,7 @@ params {
 	// PIPELINE OPTIONS //
 	strands = 2
 	useKraken = false
+	useSkesa = true // To use spades set useSkesa = false
 }
 
 profiles {

--- a/container/build_container.sh
+++ b/container/build_container.sh
@@ -11,6 +11,7 @@ declare -A containers=(
     [ariba]=https://depot.galaxyproject.org/singularity/ariba:2.14.6--py38h6ed170a_0
     [mlst]=https://depot.galaxyproject.org/singularity/mlst:2.19.0--hdfd78af_1
     [spades]=https://depot.galaxyproject.org/singularity/spades:3.15.2--h95f258a_1
+    [skesa]=https://depot.galaxyproject.org/singularity/skesa:2.4.0--he1c1bb9_0
     [quast]=https://depot.galaxyproject.org/singularity/quast:5.0.2--py37pl5262h190e900_4
     [freebayes]=https://depot.galaxyproject.org/singularity/freebayes:1.3.5--py39hba5d119_3
     [perl_json]=https://depot.galaxyproject.org/singularity/perl-json%3A4.02--pl526_0


### PR DESCRIPTION
# Description
Addition of skesa assembly as an alternative option to spades:
* A container was added to the `build_container.sh.script`
* The config file was changed to accommodate skesa with the option `useSkesa=true/false` to signal it's usage
* main.nf has if else to choose assembler based on user input

## Primary function of PR
- [ ] Hotfix
- [x] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality

# Sign-offs
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
