### PR TITLE
Add correct_alleles argument to prp

### DIFF
--- a/bin/pipeline_result_processor/prp/cli.py
+++ b/bin/pipeline_result_processor/prp/cli.py
@@ -47,17 +47,12 @@ def cli():
     multiple=True,
     help="Nextflow processes metadata from the pipeline in json format",
 )
-@click.option(
-    "-k", "--kraken", type=click.File(), help="Kraken species annotation results"
-)
+@click.option("-k", "--kraken", type=click.File(), help="Kraken species annotation results")
 @click.option("-m", "--mlst", type=click.File(), help="MLST prediction results")
 @click.option("-c", "--cgmlst", type=click.File(), help="cgMLST prediction results")
-@click.option(
-    "-v", "--virulence", type=click.File(), help="Virulence factor prediction results"
-)
-@click.option(
-    "-r", "--resistance", type=click.File(), help="Resistance prediction results"
-)
+@click.option("-v", "--virulence", type=click.File(), help="Virulence factor prediction results")
+@click.option("-r", "--resistance", type=click.File(), help="Resistance prediction results")
+@click.option("-a", "--correct_alleles", is_flag=True, help="Correct alleles")
 @click.argument("output", type=click.File("w"))
 def create_output(
     sample_id,
@@ -69,6 +64,7 @@ def create_output(
     cgmlst,
     virulence,
     resistance,
+    correct_alleles,
     output,
 ):
     """Combine pipeline results into a standardized json output file."""
@@ -102,7 +98,7 @@ def create_output(
         res: MethodIndex = parse_mlst_results(mlst)
         results["typing_result"].append(res)
     if cgmlst:
-        res: MethodIndex = parse_cgmlst_results(cgmlst)
+        res: MethodIndex = parse_cgmlst_results(cgmlst, correct_alleles=correct_alleles)
         results["typing_result"].append(res)
 
     # resistance of different types

--- a/bin/pipeline_result_processor/prp/parse/typing.py
+++ b/bin/pipeline_result_processor/prp/parse/typing.py
@@ -47,12 +47,16 @@ def parse_cgmlst_results(
     def replace_errors(allele):
         """Replace errors and novel alleles with nulls if they are not to be inlcuded."""
         if any(
-            [allele in ERRORS, allele.startswith("INF") and not include_novel_alleles]
+            [correct_alleles and allele in ERRORS, correct_alleles and allele.startswith("INF") and not include_novel_alleles]
         ):
             return None
         elif allele.startswith("INF") and include_novel_alleles:
             return int(allele.split("-")[1])
-        return int(allele)
+        try:
+            allele = int(allele)
+        except ValueError:
+            allele = str(allele)
+        return allele
 
     msg = "Parsing cgmslt results, "
     LOG.info(
@@ -62,7 +66,7 @@ def parse_cgmlst_results(
     _, *allele_names = (colname.rstrip(".fasta") for colname in next(creader))
     # parse alleles
     _, *alleles = next(creader)
-    corrected_alleles = (replace_errors(a) if correct_alleles else a for a in alleles)
+    corrected_alleles = (replace_errors(a) for a in alleles)
     results = TypingResultCgMlst(
         n_novel=sum(1 for a in alleles if a.startswith("INF")),
         n_missing=sum(1 for a in alleles if a in ERRORS),

--- a/bin/pipeline_result_processor/prp/parse/typing.py
+++ b/bin/pipeline_result_processor/prp/parse/typing.py
@@ -28,7 +28,7 @@ def parse_mlst_results(path: str) -> TypingResultMlst:
 
 
 def parse_cgmlst_results(
-    file: str, include_novel_alleles: bool = True
+    file: str, include_novel_alleles: bool = True, correct_alleles: bool = False
 ) -> TypingResultCgMlst:
     """Parse chewbbaca cgmlst prediction results to json results.
 
@@ -62,7 +62,7 @@ def parse_cgmlst_results(
     _, *allele_names = (colname.rstrip(".fasta") for colname in next(creader))
     # parse alleles
     _, *alleles = next(creader)
-    corrected_alleles = (replace_errors(a) for a in alleles)
+    corrected_alleles = (replace_errors(a) if correct_alleles else a for a in alleles)
     results = TypingResultCgMlst(
         n_novel=sum(1 for a in alleles if a.startswith("INF")),
         n_missing=sum(1 for a in alleles if a in ERRORS),


### PR DESCRIPTION
# Description
_Summary of the changes made:_
* Pipeline results processor has an optional argument `--correct_alleles` to correct allele calls that aren't digits (`["LNF", "PLOT3", "PLOT5", "NIPH", "NIPHEM", "ALM", "ASM"]`) by changing them to `null`.

## Primary function of PR
- [ ] Hotfix
- [x] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality

# Testing
Tested using using prp input
