### PR TITLE
Chewy image hotfix

### DIFF
--- a/container/chewbbaca
+++ b/container/chewbbaca
@@ -17,7 +17,8 @@ From:condaforge/mambaforge:22.9.0-2
      MAFFT_VERSION=7.505
   
          /opt/conda/bin/mamba install -k -q -y -c bioconda -c conda-forge "numpy>=1.23.4" "scipy>=1.9.3" "biopython>=1.78" "plotly>=5.8.0" "SPARQLWrapper>=2.0.0" "requests>=2.27.1" "pandas>=1.5.1" 
-         /opt/conda/bin/mamba install -k -q -y -c bioconda -c conda-forge "BLAST>=${BLAST_VERSION}" "Prodigal>=${PRODIGAL_VERSION}" "MAFFT>=${MAFFT_VERSION}"
+         /opt/conda/bin/mamba install -k -q -y -c bioconda -c conda-forge "BLAST>=${BLAST_VERSION}" "Prodigal>=${PRODIGAL_VERSION}"
+         /opt/conda/bin/mamba install -k -q -y -c bioconda -c conda-forge "MAFFT>=${MAFFT_VERSION}"
          /opt/conda/bin/mamba install -k -q -y pip
          /opt/conda/bin/pip install "chewbbaca==${CHEWBBACA_VERSION}"
 

--- a/container/chewbbaca
+++ b/container/chewbbaca
@@ -1,5 +1,5 @@
 Bootstrap:docker
-From:condaforge/mambaforge:22.9.0-3
+From:condaforge/mambaforge:22.9.0-2
 
 
 %labels

--- a/container/chewbbaca
+++ b/container/chewbbaca
@@ -5,7 +5,7 @@ From:condaforge/mambaforge:22.9.0-2
 %labels
 	MAINTAINER Ryan Kennedy <ryan.kennedy@skane.se>
 	DESCRIPTION Singularity container for CMD microbiology WGS pipeline
-	VERSION 3.1.0
+	VERSION 3.2.0
 
 %environment
 	umask 0002
@@ -15,9 +15,11 @@ From:condaforge/mambaforge:22.9.0-2
      BLAST_VERSION=2.9.0
      PRODIGAL_VERSION=2.6.3
      MAFFT_VERSION=7.505
-	 
-	 mamba install -c bioconda -c conda-forge numpy>=1.23.4 scipy>=1.9.3 biopython>=1.78 plotly>=5.8.0 SPARQLWrapper>=2.0.0 requests>=2.27.1 pandas>=1.5.1 BLAST>="${BLAST_VERSION}" Prodigal>="${PRODIGAL_VERSION}" MAFFT>="${MAFFT_VERSION}"
-	 pip install chewbbaca=="${CHEWBBACA_VERSION}"
+  
+         /opt/conda/bin/mamba install -k -q -y -c bioconda -c conda-forge "numpy>=1.23.4" "scipy>=1.9.3" "biopython>=1.78" "plotly>=5.8.0" "SPARQLWrapper>=2.0.0" "requests>=2.27.1" "pandas>=1.5.1" 
+         /opt/conda/bin/mamba install -k -q -y -c bioconda -c conda-forge "BLAST>=${BLAST_VERSION}" "Prodigal>=${PRODIGAL_VERSION}" "MAFFT>=${MAFFT_VERSION}"
+         /opt/conda/bin/mamba install -k -q -y pip
+         /opt/conda/bin/pip install "chewbbaca==${CHEWBBACA_VERSION}"
 
 %test
      /opt/conda/bin/chewBBACA.py -V


### PR DESCRIPTION
# Description

- Backrolled chewy one version to resolve OCI check failure
- Made binary calls explicit to avoid failure
- Changed version syntax to avoid crashes
- Split mamba invocation to avoid throttling disconnect

## Primary function of PR
- [ ] Hotfix
- [x] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality

# Testing
```
cd container
sudo -E singularity build --force chewy chewbbaca
```

# Sign-offs
- [x] Code reviewed by @ryanjameskennedy 
- [x] Code tested by @sylvinite 
