### PR TITLE
Blast image

### DIFF
--- a/container/build_container.sh
+++ b/container/build_container.sh
@@ -15,6 +15,8 @@ declare -A containers=(
     [quast]=https://depot.galaxyproject.org/singularity/quast:5.2.0--py310pl5321hc8f18ef_2
     [freebayes]=https://depot.galaxyproject.org/singularity/freebayes:1.3.6--hbfe0e7f_2
     [perl_json]=https://depot.galaxyproject.org/singularity/perl-json:4.10--pl5321hdfd78af_0
+    [blast]=https://depot.galaxyproject.org/singularity/blast%3A2.14.0--hf3cf87c_0
+
 )
 
 for tool in "${definitions[@]}"; do

--- a/container/build_container.sh
+++ b/container/build_container.sh
@@ -15,7 +15,7 @@ declare -A containers=(
     [quast]=https://depot.galaxyproject.org/singularity/quast:5.2.0--py310pl5321hc8f18ef_2
     [freebayes]=https://depot.galaxyproject.org/singularity/freebayes:1.3.6--hbfe0e7f_2
     [perl_json]=https://depot.galaxyproject.org/singularity/perl-json:4.10--pl5321hdfd78af_0
-    [blast]=https://depot.galaxyproject.org/singularity/blast%3A2.14.0--hf3cf87c_0
+    [blast]=https://depot.galaxyproject.org/singularity/blast:2.14.0--hf3cf87c_0
 
 )
 

--- a/container/pythonScripts
+++ b/container/pythonScripts
@@ -14,3 +14,4 @@ From:python
 
 %post
 	pip install -e /pipeline_result_processor
+        pip install  biopython

--- a/deploy/deploy_references_singularity.sh
+++ b/deploy/deploy_references_singularity.sh
@@ -21,7 +21,7 @@ singularity exec --bind $mntroot ${containerdir}/amrfinderplus.sif amrfinder_upd
 #MLST db
 cd ${assdir}/mlst_db
 bash ./mlst-download_pub_mlst.sh &> /dev/null
-singularity exec $mntroot --bind  ${containerdir}/blast.sif bash ${assdir}/mlst_db/mlst-make_blast_db.sh &> /dev/null
+singularity exec --bind $mntroot ${containerdir}/blast.sif bash ${assdir}/mlst_db/mlst-make_blast_db.sh &> /dev/null
 
 #Finder dbs
 cd ${assdir}/kma && make

--- a/deploy/deploy_references_singularity.sh
+++ b/deploy/deploy_references_singularity.sh
@@ -21,7 +21,7 @@ singularity exec --bind $mntroot ${containerdir}/amrfinderplus.sif amrfinder_upd
 #MLST db
 cd ${assdir}/mlst_db
 bash ./mlst-download_pub_mlst.sh &> /dev/null
-bash ./mlst-make_blast_db.sh &> /dev/null
+singularity exec $mntroot --bind  ${containerdir}/blast.sif bash ${assdir}/mlst_db/mlst-make_blast_db.sh &> /dev/null
 
 #Finder dbs
 cd ${assdir}/kma && make


### PR DESCRIPTION
# Description
_##Remove elements in cursive as needed.##_

1. biopython was not installed in "pythonscripts". Therefore you got an importer error when running download_ncbi.py

2. blast did not have a singularity image and therefore it was assumed that the user had blast in their path.



_Summary of the changes made:_
1. Added a pip install biopython statement in the recepie file for biopython
2. Added a singularity image download statement in build_container.sh. modified the make_blast_db command in deploy_references:singularity.sh
## Primary function of PR
- [ x] Hotfix
- [ ] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality

# Testing
_Either describe a procedure, or add data; that confirms that the PR resolves what it sets out to do_
I ran the installation procedure again. The files created by mlst-make_blast_db.sh was now created

```
if [ -d "$saureus" ]; then echo "$saureus exists."; else echo "ERROR: $saureus does not existsaureus=${assdir}/cgmlst/staphylococcus_aureus/alleles_rereffed! Please report this to JASEN issues."; fi
/aux/db/JASEN/deploy/../assets//cgmlst/staphylococcus_aureus/alleles_rereffed exists.
if [[ -f $ref && -f $refamb && -f $refann && -f $refbwt && -f $refpac && -f $refsa ]]; then echo "bwa indexes exists."; else echo "ERROR: bwa indexes do not existref=${assdir}/genomes/staphylococcus_aureus/NC_002951.2.fasta; refamb=$ref.amb; refann=$ref.ann; refbwt=$ref.bwt; refpac=$ref.pac; refsa=$ref.sa! Please report this to JASEN issues."; fi
bwa indexes exists.
if [[ -f $mlst && -f $mlstndb && -f $mlstnhd && -f $mlstnhi && -f $mlstnhr && -f $mlstnin && -f $mlstnog && -f $mlstnos && -f $mlstnot && -f $mlstnsq && -f $mlstntf && -f $mlstnto ]]; then echo "BLAST indexes exists!"; else echo "ERROR: BLAST indexes do not existmlst=${assdir}/mlst_db/blast/mlst.fa; mlstndb=$mlst.ndb; mlstnhd=$mlst.nhd; mlstnhi=$mlst.nhi; mlstnhr=$mlst.nhr; mlstnin=$mlst.nin; mlstnog=$mlst.nog; mlstnos=$mlst.nos; mlstnot=$mlst.not; mlstnsq=$mlst.nsq; mlstntf=$mlst.ntf; mlstnto=$mlst.nto! Please report this to JASEN issues."; fi
BLAST indexes exists!

```
# Sign-offs
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
