### PR TITLE
Origin/update output format

### DIFF
--- a/bin/pipeline_result_processor/prp/cli.py
+++ b/bin/pipeline_result_processor/prp/cli.py
@@ -81,7 +81,7 @@ def create_output(
         "run_metadata": {"run": run_info},
         "qc": [],
         "typing_result": [],
-        "element_type_result": {"antimicrobial_resistance": {}, "chemical_resistance": {}, "environmental_resistance": {}, "metal_resistance": {}, "virulence": {}},
+        "element_type_result": [],
     }
     if process_metadata:
         db_info: List[SoupVersion] = []
@@ -108,30 +108,24 @@ def create_output(
     # resfinder of different types
     if resistance:
         pred_res = json.load(resistance)
-        res: MethodIndex = parse_resfinder_amr_pred(pred_res, ElementType.AMR)
-        chem: MethodIndex = parse_resfinder_amr_pred(pred_res, ElementType.BIOCIDE)
-        env: MethodIndex = parse_resfinder_amr_pred(pred_res, ElementType.HEAT)
-        results["element_type_result"]["antimicrobial_resistance"]["resfinder"] = res
-        results["element_type_result"]["chemical_resistance"]["resfinder"] = chem
-        results["element_type_result"]["environmental_resistance"]["resfinder"] = env
+        methods = [ElementType.AMR, ElementType.BIOCIDE, ElementType.HEAT]
+        for method in methods:
+            res: MethodIndex = parse_resfinder_amr_pred(pred_res, method)
+            results["element_type_result"].append(res)
 
     # amrfinder
     if amr:
-        res = parse_amrfinder_amr_pred(amr, ElementType.AMR)
-        chem = parse_amrfinder_amr_pred(amr, ElementType.BIOCIDE)
-        metal = parse_amrfinder_amr_pred(amr, ElementType.METAL)
-        env = parse_amrfinder_amr_pred(amr, ElementType.HEAT)
-        vir = parse_amrfinder_vir_pred(amr)
-        results["element_type_result"]["antimicrobial_resistance"]["amrfinder"] = res
-        results["element_type_result"]["chemical_resistance"]["amrfinder"] = chem
-        results["element_type_result"]["environmental_resistance"]["amrfinder"] = env
-        results["element_type_result"]["metal_resistance"]["amrfinder"] = metal
-        results["element_type_result"]["virulence"]["amrfinder"] = vir
+        methods = [ElementType.AMR, ElementType.BIOCIDE, ElementType.METAL, ElementType.HEAT] 
+        for method in methods:
+            res: MethodIndex = parse_amrfinder_amr_pred(amr, method)
+            results["element_type_result"].append(res)
+        vir: MethodIndex = parse_amrfinder_vir_pred(amr)
+        results["element_type_result"].append(vir)
 
     # get virulence factors in sample
     if virulence:
         vir: MethodIndex = parse_virulencefinder_vir_pred(virulence)
-        results["element_type_result"]["virulence"]["virulencefinder"] = vir
+        results["element_type_result"].append(vir)
 
     if kraken:
         LOG.info("Parse kraken results")

--- a/bin/pipeline_result_processor/prp/cli.py
+++ b/bin/pipeline_result_processor/prp/cli.py
@@ -122,7 +122,9 @@ def create_output(
         methods = [ElementType.AMR, ElementType.BIOCIDE, ElementType.HEAT]
         for method in methods:
             res: MethodIndex = parse_resfinder_amr_pred(pred_res, method)
-            results["element_type_result"].append(res)
+            # exclude empty results from output
+            if len(res.result.genes) > 0 and len(res.result.mutations) > 0:
+                results["element_type_result"].append(res)
 
     # amrfinder
     if amr:

--- a/bin/pipeline_result_processor/prp/cli.py
+++ b/bin/pipeline_result_processor/prp/cli.py
@@ -49,12 +49,23 @@ def cli():
     multiple=True,
     help="Nextflow processes metadata from the pipeline in json format",
 )
-@click.option("-k", "--kraken", type=click.File(), help="Kraken species annotation results")
-@click.option("-a", "--amr", type=str, help="amrfinderplus anti-microbial resistance results")
+@click.option(
+    "-k", "--kraken", type=click.File(), help="Kraken species annotation results"
+)
+@click.option(
+    "-a", "--amr", type=str, help="amrfinderplus anti-microbial resistance results"
+)
 @click.option("-m", "--mlst", type=click.File(), help="MLST prediction results")
 @click.option("-c", "--cgmlst", type=click.File(), help="cgMLST prediction results")
-@click.option("-v", "--virulence", type=click.File(), help="Virulence factor prediction results")
-@click.option("-r", "--resistance", type=click.File(), help="resfinder resistance prediction results")
+@click.option(
+    "-v", "--virulence", type=click.File(), help="Virulence factor prediction results"
+)
+@click.option(
+    "-r",
+    "--resistance",
+    type=click.File(),
+    help="resfinder resistance prediction results",
+)
 @click.option("--correct_alleles", is_flag=True, help="Correct alleles")
 @click.argument("output", type=click.File("w"))
 def create_output(
@@ -115,7 +126,12 @@ def create_output(
 
     # amrfinder
     if amr:
-        methods = [ElementType.AMR, ElementType.BIOCIDE, ElementType.METAL, ElementType.HEAT] 
+        methods = [
+            ElementType.AMR,
+            ElementType.BIOCIDE,
+            ElementType.METAL,
+            ElementType.HEAT,
+        ]
         for method in methods:
             res: MethodIndex = parse_amrfinder_amr_pred(amr, method)
             results["element_type_result"].append(res)

--- a/bin/pipeline_result_processor/prp/models/__init__.py
+++ b/bin/pipeline_result_processor/prp/models/__init__.py
@@ -1,0 +1,1 @@
+from .base import Software

--- a/bin/pipeline_result_processor/prp/models/__init__.py
+++ b/bin/pipeline_result_processor/prp/models/__init__.py
@@ -1,1 +1,0 @@
-from .base import Software

--- a/bin/pipeline_result_processor/prp/models/base.py
+++ b/bin/pipeline_result_processor/prp/models/base.py
@@ -5,18 +5,6 @@ from enum import Enum
 from pydantic import BaseConfig, BaseModel
 
 
-class Software(Enum):
-    """Container for software names."""
-
-    # phenotype
-    AMRFINDER = "amrfinder"
-    RESFINDER = "resfinder"
-    VIRFINDER = "virulencefinder"
-    # typing
-    CHEWBACCA = "chewbbacca"
-    MLST = "mlst"
-
-
 class RWModel(BaseModel):
     """Base model for read/ write operations"""
 

--- a/bin/pipeline_result_processor/prp/models/base.py
+++ b/bin/pipeline_result_processor/prp/models/base.py
@@ -1,7 +1,20 @@
 """Generic database objects of which several other models are based on."""
 from datetime import datetime
+from enum import Enum
 
-from pydantic import BaseConfig, BaseModel, Field
+from pydantic import BaseConfig, BaseModel
+
+
+class Software(Enum):
+    """Container for software names."""
+
+    # phenotype
+    AMRFINDER = "amrfinder"
+    RESFINDER = "resfinder"
+    VIRFINDER = "virulencefinder"
+    # typing
+    CHEWBACCA = "chewbbacca"
+    MLST = "mlst"
 
 
 class RWModel(BaseModel):

--- a/bin/pipeline_result_processor/prp/models/phenotype.py
+++ b/bin/pipeline_result_processor/prp/models/phenotype.py
@@ -7,6 +7,15 @@ from pydantic import BaseModel, Field
 from .base import RWModel
 
 
+class PredictionSoftware(Enum):
+    """Container for software names."""
+
+    # phenotype
+    AMRFINDER = "amrfinder"
+    RESFINDER = "resfinder"
+    VIRFINDER = "virulencefinder"
+
+
 class VariantType(Enum):
     SUBSTITUTION = "substitution"
 

--- a/bin/pipeline_result_processor/prp/models/phenotype.py
+++ b/bin/pipeline_result_processor/prp/models/phenotype.py
@@ -46,7 +46,7 @@ class GeneBase(BaseModel):
     ref_end_pos: Union[int, None]
     ref_gene_length: Union[int, None]
     alignment_length: Union[int, None]
-    #amrfinder extra info
+    # amrfinder extra info
     contig_id: Union[str, None]
     gene_symbol: Union[str, None]
     sequence_name: Union[str, None]
@@ -102,5 +102,5 @@ class ElementTypeResult(BaseModel):
     """
 
     phenotypes: Dict[str, List[str]]
-    genes: List[ Union[ResistanceGene , VirulenceGene] ]
+    genes: List[Union[ResistanceGene, VirulenceGene]]
     mutations: List[ResistanceVariant]

--- a/bin/pipeline_result_processor/prp/models/qc.py
+++ b/bin/pipeline_result_processor/prp/models/qc.py
@@ -30,5 +30,5 @@ class QuastQcResult(BaseModel):
 
 class QcMethodIndex(RWModel):
     software: QcSoftware
-    version: Union[ str , None ]
+    version: Union[str, None]
     result: QuastQcResult

--- a/bin/pipeline_result_processor/prp/models/qc.py
+++ b/bin/pipeline_result_processor/prp/models/qc.py
@@ -8,7 +8,7 @@ from typing import Union
 from .base import RWModel
 
 
-class QcTool(Enum):
+class QcSoftware(Enum):
     """Valid tools."""
 
     QUAST = "quast"
@@ -29,6 +29,6 @@ class QuastQcResult(BaseModel):
 
 
 class QcMethodIndex(RWModel):
-    tool: QcTool
+    software: QcSoftware
     version: Union[ str , None ]
     result: QuastQcResult

--- a/bin/pipeline_result_processor/prp/models/sample.py
+++ b/bin/pipeline_result_processor/prp/models/sample.py
@@ -1,10 +1,10 @@
 """Data model definition of input/ output data"""
 from enum import Enum
-from typing import Dict, List, Union
+from typing import List, Union
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
-from .base import RWModel
+from .base import RWModel, Software
 from .metadata import RunMetadata
 from .phenotype import ElementTypeResult, ElementType
 from .qc import QcMethodIndex
@@ -34,7 +34,10 @@ class SpeciesPrediction(RWModel):
 
 
 class MethodIndex(RWModel):
+    """Container for key-value lookup of analytical results."""
+
     type: Union[ElementType, TypingMethod]
+    software: Software | None
     result: Union[ElementTypeResult, TypingResultMlst, TypingResultCgMlst]
 
 
@@ -56,4 +59,4 @@ class PipelineResult(SampleBase):
     # optional typing
     typing_result: List[MethodIndex] = Field(..., alias="typingResult")
     # optional phenotype prediction
-    element_type_result: Dict[str, Dict[str, MethodIndex]] = Field(..., alias="elementTypeResult")
+    element_type_result: List[MethodIndex] = Field(..., alias="elementTypeResult")

--- a/bin/pipeline_result_processor/prp/models/sample.py
+++ b/bin/pipeline_result_processor/prp/models/sample.py
@@ -4,11 +4,11 @@ from typing import List, Union
 
 from pydantic import Field
 
-from .base import RWModel, Software
+from .base import RWModel
 from .metadata import RunMetadata
-from .phenotype import ElementTypeResult, ElementType
+from .phenotype import ElementTypeResult, ElementType, PredictionSoftware
 from .qc import QcMethodIndex
-from .typing import TypingMethod, TypingResultCgMlst, TypingResultMlst
+from .typing import TypingMethod, TypingResultCgMlst, TypingResultMlst, TypingSoftware
 
 # disabled validation
 # SAMPLE_ID_PATTERN = r"^[a-zA-Z1-9-_]+$"
@@ -37,7 +37,7 @@ class MethodIndex(RWModel):
     """Container for key-value lookup of analytical results."""
 
     type: Union[ElementType, TypingMethod]
-    software: Software | None
+    software: PredictionSoftware | TypingSoftware | None
     result: Union[ElementTypeResult, TypingResultMlst, TypingResultCgMlst]
 
 

--- a/bin/pipeline_result_processor/prp/models/sample.py
+++ b/bin/pipeline_result_processor/prp/models/sample.py
@@ -44,9 +44,7 @@ class MethodIndex(RWModel):
 class SampleBase(RWModel):
     """Base datamodel for sample data structure"""
 
-    sample_id: str = Field(
-        ..., alias="sampleId", min_length=3, max_length=100
-    )
+    sample_id: str = Field(..., alias="sampleId", min_length=3, max_length=100)
     run_metadata: RunMetadata = Field(..., alias="runMetadata")
     qc: List[QcMethodIndex] = Field(...)
     species_prediction: List[SpeciesPrediction] = Field(..., alias="speciesPrediction")

--- a/bin/pipeline_result_processor/prp/models/typing.py
+++ b/bin/pipeline_result_processor/prp/models/typing.py
@@ -8,6 +8,13 @@ from pydantic import Field
 from .base import RWModel
 
 
+class TypingSoftware(Enum):
+    """Container for software names."""
+    # typing
+    CHEWBBACA = "chewbbaca"
+    MLST = "mlst"
+
+
 class TypingMethod(Enum):
     MLST = "mlst"
     CGMLST = "cgmlst"

--- a/bin/pipeline_result_processor/prp/models/typing.py
+++ b/bin/pipeline_result_processor/prp/models/typing.py
@@ -10,6 +10,7 @@ from .base import RWModel
 
 class TypingSoftware(Enum):
     """Container for software names."""
+
     # typing
     CHEWBBACA = "chewbbaca"
     MLST = "mlst"

--- a/bin/pipeline_result_processor/prp/parse/__init__.py
+++ b/bin/pipeline_result_processor/prp/parse/__init__.py
@@ -1,6 +1,11 @@
 """Parse output of softwares in pipeline."""
 
-from .phenotype import parse_resfinder_amr_pred, parse_amrfinder_amr_pred, parse_virulencefinder_vir_pred, parse_amrfinder_vir_pred
+from .phenotype import (
+    parse_resfinder_amr_pred,
+    parse_amrfinder_amr_pred,
+    parse_virulencefinder_vir_pred,
+    parse_amrfinder_vir_pred,
+)
 from .qc import parse_quast_results
 from .species import parse_kraken_result
 from .typing import parse_cgmlst_results, parse_mlst_results

--- a/bin/pipeline_result_processor/prp/parse/phenotype.py
+++ b/bin/pipeline_result_processor/prp/parse/phenotype.py
@@ -13,7 +13,7 @@ from ..models.phenotype import (
     ResistanceVariant,
     VirulenceGene,
 )
-from ..models import Software
+from ..models.phenotype import PredictionSoftware as Software
 from ..models.sample import MethodIndex
 
 LOG = logging.getLogger(__name__)

--- a/bin/pipeline_result_processor/prp/parse/phenotype.py
+++ b/bin/pipeline_result_processor/prp/parse/phenotype.py
@@ -25,7 +25,10 @@ def _get_resfinder_amr_sr_profie(resfinder_result, limit_to_phenotypes=None):
     resistant = set()
     for phenotype in resfinder_result["phenotypes"].values():
         # skip phenotype if its not part of the desired category
-        if (limit_to_phenotypes is not None and phenotype["key"] not in limit_to_phenotypes):
+        if (
+            limit_to_phenotypes is not None
+            and phenotype["key"] not in limit_to_phenotypes
+        ):
             continue
 
         if "amr_resistant" in phenotype.keys():
@@ -36,12 +39,14 @@ def _get_resfinder_amr_sr_profie(resfinder_result, limit_to_phenotypes=None):
     return {"susceptible": list(susceptible), "resistant": list(resistant)}
 
 
-def _parse_resfinder_amr_genes(resfinder_result, limit_to_phenotypes=None) -> Tuple[ResistanceGene, ...]:
+def _parse_resfinder_amr_genes(
+    resfinder_result, limit_to_phenotypes=None
+) -> Tuple[ResistanceGene, ...]:
     """Get resistance genes from resfinder result."""
     results = []
 
     if not "seq_regions" in resfinder_result:
-        results  = _default_resistance().genes
+        results = _default_resistance().genes
         return results
 
     for info in resfinder_result["seq_regions"].values():
@@ -74,7 +79,9 @@ def _parse_resfinder_amr_genes(resfinder_result, limit_to_phenotypes=None) -> Tu
     return results
 
 
-def _parse_resfinder_amr_variants(resfinder_result, limit_to_phenotypes=None) -> Tuple[ResistanceVariant, ...]:
+def _parse_resfinder_amr_variants(
+    resfinder_result, limit_to_phenotypes=None
+) -> Tuple[ResistanceVariant, ...]:
     """Get resistance genes from resfinder result."""
     results = []
     igenes = []
@@ -86,7 +93,9 @@ def _parse_resfinder_amr_variants(resfinder_result, limit_to_phenotypes=None) ->
                 continue
         # get gene depth
         if "seq_regions" in resfinder_result:
-            info["depth"] = resfinder_result["seq_regions"][info["seq_regions"][0]]["depth"]
+            info["depth"] = resfinder_result["seq_regions"][info["seq_regions"][0]][
+                "depth"
+            ]
         else:
             info["depth"] = 0
         # translate variation type bools into classifier
@@ -99,7 +108,7 @@ def _parse_resfinder_amr_variants(resfinder_result, limit_to_phenotypes=None) ->
         else:
             raise ValueError("Output has no known mutation type")
         if not "seq_regions" in info:
-            #igenes = _default_resistance().genes
+            # igenes = _default_resistance().genes
             igenes = [""]
         variant = ResistanceVariant(
             variant_type=var_type,
@@ -115,43 +124,45 @@ def _parse_resfinder_amr_variants(resfinder_result, limit_to_phenotypes=None) ->
         results.append(variant)
     return results
 
+
 def _parse_amrfinder_amr_results(predictions: dict) -> Tuple[ResistanceGene, ...]:
     """Parse amrfinder prediction results from amrfinderplus."""
     genes = []
     for prediction in predictions:
         gene = ResistanceGene(
-            virulence_category = None,
-            accession = prediction["close_seq_accn"],
-            depth = None,
-            identity = prediction["ref_seq_identity"],
-            coverage = prediction["ref_seq_cov"],
-            ref_start_pos = None,
-            ref_end_pos = None,
-            ref_gene_length = prediction["ref_seq_len"],
-            alignment_length = prediction["align_len"],
-            ref_database = None,
-            phenotypes = [],
-            ref_id = None,
-
-            contig_id = prediction["contig_id"],
-            gene_symbol = prediction["gene_symbol"],
-            sequence_name = prediction["sequence_name"],
-            ass_start_pos = prediction["Start"],
-            ass_end_pos = prediction["Stop"],
-            strand = prediction["Strand"],
-            element_type = prediction["element_type"],
-            element_subtype = prediction["element_subtype"],
-            target_length = prediction["target_length"],
-            res_class = prediction["Class"],
-            res_subclass = prediction["Subclass"],
-            method = prediction["Method"],
-            close_seq_name = prediction["close_seq_name"],
+            virulence_category=None,
+            accession=prediction["close_seq_accn"],
+            depth=None,
+            identity=prediction["ref_seq_identity"],
+            coverage=prediction["ref_seq_cov"],
+            ref_start_pos=None,
+            ref_end_pos=None,
+            ref_gene_length=prediction["ref_seq_len"],
+            alignment_length=prediction["align_len"],
+            ref_database=None,
+            phenotypes=[],
+            ref_id=None,
+            contig_id=prediction["contig_id"],
+            gene_symbol=prediction["gene_symbol"],
+            sequence_name=prediction["sequence_name"],
+            ass_start_pos=prediction["Start"],
+            ass_end_pos=prediction["Stop"],
+            strand=prediction["Strand"],
+            element_type=prediction["element_type"],
+            element_subtype=prediction["element_subtype"],
+            target_length=prediction["target_length"],
+            res_class=prediction["Class"],
+            res_subclass=prediction["Subclass"],
+            method=prediction["Method"],
+            close_seq_name=prediction["close_seq_name"],
         )
         genes.append(gene)
     return ElementTypeResult(phenotypes=[], genes=genes, mutations=[])
 
 
-def parse_resfinder_amr_pred(prediction: Dict[str, Any], resistance_category) -> Tuple[SoupVersions, ElementTypeResult]:
+def parse_resfinder_amr_pred(
+    prediction: Dict[str, Any], resistance_category
+) -> Tuple[SoupVersions, ElementTypeResult]:
     """Parse resfinder resistance prediction results."""
     # resfinder missclassifies resistance the param amr_category by setting all to amr
     LOG.info("Parsing resistance prediction")
@@ -184,11 +195,17 @@ def parse_resfinder_amr_pred(prediction: Dict[str, Any], resistance_category) ->
 
     # parse resistance
     resistance = ElementTypeResult(
-        phenotypes = _get_resfinder_amr_sr_profie(prediction, categories[resistance_category]),
-        genes = _parse_resfinder_amr_genes(prediction, categories[resistance_category]),
-        mutations = _parse_resfinder_amr_variants(prediction, categories[resistance_category]),
+        phenotypes=_get_resfinder_amr_sr_profie(
+            prediction, categories[resistance_category]
+        ),
+        genes=_parse_resfinder_amr_genes(prediction, categories[resistance_category]),
+        mutations=_parse_resfinder_amr_variants(
+            prediction, categories[resistance_category]
+        ),
     )
-    return MethodIndex(type=resistance_category, software=Software.RESFINDER, result=resistance)
+    return MethodIndex(
+        type=resistance_category, software=Software.RESFINDER, result=resistance
+    )
 
 
 def parse_amrfinder_amr_pred(file, element_type: str) -> ElementTypeResult:
@@ -196,27 +213,46 @@ def parse_amrfinder_amr_pred(file, element_type: str) -> ElementTypeResult:
     LOG.info("Parsing amrfinder amr prediction")
     with open(file, "rb") as tsvfile:
         hits = pd.read_csv(tsvfile, delimiter="\t")
-        hits = hits.rename(columns={"Contig id": "contig_id", "Gene symbol": "gene_symbol", "Sequence name": "sequence_name", "Element type": "element_type", 
-                                    "Element subtype": "element_subtype", "Target length": "target_length", "Reference sequence length": "ref_seq_len", 
-                                    "% Coverage of reference sequence": "ref_seq_cov", "% Identity to reference sequence": "ref_seq_identity", 
-                                    "Alignment length": "align_len", "Accession of closest sequence": "close_seq_accn", "Name of closest sequence": "close_seq_name"})
+        hits = hits.rename(
+            columns={
+                "Contig id": "contig_id",
+                "Gene symbol": "gene_symbol",
+                "Sequence name": "sequence_name",
+                "Element type": "element_type",
+                "Element subtype": "element_subtype",
+                "Target length": "target_length",
+                "Reference sequence length": "ref_seq_len",
+                "% Coverage of reference sequence": "ref_seq_cov",
+                "% Identity to reference sequence": "ref_seq_identity",
+                "Alignment length": "align_len",
+                "Accession of closest sequence": "close_seq_accn",
+                "Name of closest sequence": "close_seq_name",
+            }
+        )
         hits = hits.drop(columns=["Protein identifier", "HMM id", "HMM description"])
         hits = hits.where(pd.notnull(hits), None)
         if element_type == ElementType.AMR:
             predictions = hits[hits["element_type"] == "AMR"].to_dict(orient="records")
             results: ElementTypeResult = _parse_amrfinder_amr_results(predictions)
         elif element_type == ElementType.HEAT:
-            predictions = hits[(hits["element_subtype"] == "HEAT")].to_dict(orient="records")
+            predictions = hits[(hits["element_subtype"] == "HEAT")].to_dict(
+                orient="records"
+            )
             results: ElementTypeResult = _parse_amrfinder_amr_results(predictions)
         elif element_type == ElementType.BIOCIDE:
-            predictions = hits[(hits["element_subtype"] == "ACID") & (hits["element_subtype"] == "BIOCIDE")].to_dict(orient="records")
+            predictions = hits[
+                (hits["element_subtype"] == "ACID")
+                & (hits["element_subtype"] == "BIOCIDE")
+            ].to_dict(orient="records")
             results: ElementTypeResult = _parse_amrfinder_amr_results(predictions)
         elif element_type == ElementType.METAL:
-            predictions = hits[hits["element_subtype"] == "METAL"].to_dict(orient="records")
+            predictions = hits[hits["element_subtype"] == "METAL"].to_dict(
+                orient="records"
+            )
             results: ElementTypeResult = _parse_amrfinder_amr_results(predictions)
         else:
             results = _default_resistance()
-    return MethodIndex(type = element_type, result = results, software = Software.AMRFINDER)
+    return MethodIndex(type=element_type, result=results, software=Software.AMRFINDER)
 
 
 def _parse_virulencefinder_vir_results(pred: str) -> ElementTypeResult:
@@ -249,41 +285,42 @@ def _parse_virulencefinder_vir_results(pred: str) -> ElementTypeResult:
 
     return ElementTypeResult(results)
 
-def _parse_amrfinder_vir_results(predictions: dict)  -> ElementTypeResult:
+
+def _parse_amrfinder_vir_results(predictions: dict) -> ElementTypeResult:
     """Parse amrfinder prediction results from amrfinderplus."""
     genes = []
     for prediction in predictions:
         gene = VirulenceGene(
-            name = None,
-            virulence_category = None,
-            accession = prediction["close_seq_accn"],
-            depth = None,
-            identity = prediction["ref_seq_identity"],
-            coverage = prediction["ref_seq_cov"],
-            ref_start_pos = None,
-            ref_end_pos = None,
-            ref_gene_length = prediction["ref_seq_len"],
-            alignment_length = prediction["align_len"],
-            ref_database = None,
-            phenotypes = [],
-            ref_id = None,
-
-            contig_id = prediction["contig_id"],
-            gene_symbol = prediction["gene_symbol"],
-            sequence_name = prediction["sequence_name"],
-            ass_start_pos = prediction["Start"],
-            ass_end_pos = prediction["Stop"],
-            strand = prediction["Strand"],
-            element_type = prediction["element_type"],
-            element_subtype = prediction["element_subtype"],
-            target_length = prediction["target_length"],
-            res_class = prediction["Class"],
-            res_subclass = prediction["Subclass"],
-            method = prediction["Method"],
-            close_seq_name = prediction["close_seq_name"],
+            name=None,
+            virulence_category=None,
+            accession=prediction["close_seq_accn"],
+            depth=None,
+            identity=prediction["ref_seq_identity"],
+            coverage=prediction["ref_seq_cov"],
+            ref_start_pos=None,
+            ref_end_pos=None,
+            ref_gene_length=prediction["ref_seq_len"],
+            alignment_length=prediction["align_len"],
+            ref_database=None,
+            phenotypes=[],
+            ref_id=None,
+            contig_id=prediction["contig_id"],
+            gene_symbol=prediction["gene_symbol"],
+            sequence_name=prediction["sequence_name"],
+            ass_start_pos=prediction["Start"],
+            ass_end_pos=prediction["Stop"],
+            strand=prediction["Strand"],
+            element_type=prediction["element_type"],
+            element_subtype=prediction["element_subtype"],
+            target_length=prediction["target_length"],
+            res_class=prediction["Class"],
+            res_subclass=prediction["Subclass"],
+            method=prediction["Method"],
+            close_seq_name=prediction["close_seq_name"],
         )
         genes.append(gene)
     return ElementTypeResult(phenotypes=[], genes=genes, mutations=[])
+
 
 def _default_virulence() -> ElementTypeResult:
     gene = VirulenceGene(
@@ -307,19 +344,19 @@ def _default_virulence() -> ElementTypeResult:
 
 def _default_resistance() -> ElementTypeResult:
     gene = ResistanceGene(
-        name = None,
-        virulence_category = None,
-        accession = None,
-        depth = None,
-        identity = None,
-        coverage = None,
-        ref_start_pos = None,
-        ref_end_pos = None,
-        ref_gene_length = None,
-        alignment_length = None,
-        ref_database = None,
-        phenotypes = [],
-        ref_id = None,
+        name=None,
+        virulence_category=None,
+        accession=None,
+        depth=None,
+        identity=None,
+        coverage=None,
+        ref_start_pos=None,
+        ref_end_pos=None,
+        ref_gene_length=None,
+        alignment_length=None,
+        ref_database=None,
+        phenotypes=[],
+        ref_id=None,
     )
     genes = list()
     genes.append(gene)
@@ -334,19 +371,38 @@ def parse_virulencefinder_vir_pred(file: str) -> ElementTypeResult:
         results: ElementTypeResult = _parse_virulencefinder_vir_results(pred)
     else:
         results: ElementTypeResult = _default_virulence()
-    return MethodIndex(type=ElementType.VIR, software=Software.VIRFINDER, result=results)
+    return MethodIndex(
+        type=ElementType.VIR, software=Software.VIRFINDER, result=results
+    )
+
 
 def parse_amrfinder_vir_pred(file: str):
     """Parse amrfinder virulence prediction results."""
     LOG.info("Parsing amrfinder virulence prediction")
     with open(file, "rb") as tsvfile:
         hits = pd.read_csv(tsvfile, delimiter="\t")
-        hits = hits.rename(columns={"Contig id": "contig_id", "Gene symbol": "gene_symbol", "Sequence name": "sequence_name", "Element type": "element_type", 
-                                    "Element subtype": "element_subtype", "Target length": "target_length", "Reference sequence length": "ref_seq_len", 
-                                    "% Coverage of reference sequence": "ref_seq_cov", "% Identity to reference sequence": "ref_seq_identity", 
-                                    "Alignment length": "align_len", "Accession of closest sequence": "close_seq_accn", "Name of closest sequence": "close_seq_name"})
+        hits = hits.rename(
+            columns={
+                "Contig id": "contig_id",
+                "Gene symbol": "gene_symbol",
+                "Sequence name": "sequence_name",
+                "Element type": "element_type",
+                "Element subtype": "element_subtype",
+                "Target length": "target_length",
+                "Reference sequence length": "ref_seq_len",
+                "% Coverage of reference sequence": "ref_seq_cov",
+                "% Identity to reference sequence": "ref_seq_identity",
+                "Alignment length": "align_len",
+                "Accession of closest sequence": "close_seq_accn",
+                "Name of closest sequence": "close_seq_name",
+            }
+        )
         hits = hits.drop(columns=["Protein identifier", "HMM id", "HMM description"])
         hits = hits.where(pd.notnull(hits), None)
-        predictions = hits[hits["element_type"] == "VIRULENCE"].to_dict(orient="records")
+        predictions = hits[hits["element_type"] == "VIRULENCE"].to_dict(
+            orient="records"
+        )
         results: ElementTypeResult = _parse_amrfinder_vir_results(predictions)
-    return MethodIndex(type = ElementType.VIR, software=Software.AMRFINDER, result = results)
+    return MethodIndex(
+        type=ElementType.VIR, software=Software.AMRFINDER, result=results
+    )

--- a/bin/pipeline_result_processor/prp/parse/phenotype.py
+++ b/bin/pipeline_result_processor/prp/parse/phenotype.py
@@ -1,6 +1,5 @@
 """Parse output of various phenotype predicting tools."""
 
-import csv
 import json
 import logging
 import pandas as pd
@@ -14,6 +13,7 @@ from ..models.phenotype import (
     ResistanceVariant,
     VirulenceGene,
 )
+from ..models import Software
 from ..models.sample import MethodIndex
 
 LOG = logging.getLogger(__name__)
@@ -188,7 +188,7 @@ def parse_resfinder_amr_pred(prediction: Dict[str, Any], resistance_category) ->
         genes = _parse_resfinder_amr_genes(prediction, categories[resistance_category]),
         mutations = _parse_resfinder_amr_variants(prediction, categories[resistance_category]),
     )
-    return MethodIndex(type=resistance_category, result=resistance)
+    return MethodIndex(type=resistance_category, software=Software.RESFINDER, result=resistance)
 
 
 def parse_amrfinder_amr_pred(file, element_type: str) -> ElementTypeResult:
@@ -216,7 +216,7 @@ def parse_amrfinder_amr_pred(file, element_type: str) -> ElementTypeResult:
             results: ElementTypeResult = _parse_amrfinder_amr_results(predictions)
         else:
             results = _default_resistance()
-    return MethodIndex(type = element_type, result = results)
+    return MethodIndex(type = element_type, result = results, software = Software.AMRFINDER)
 
 
 def _parse_virulencefinder_vir_results(pred: str) -> ElementTypeResult:
@@ -334,7 +334,7 @@ def parse_virulencefinder_vir_pred(file: str) -> ElementTypeResult:
         results: ElementTypeResult = _parse_virulencefinder_vir_results(pred)
     else:
         results: ElementTypeResult = _default_virulence()
-    return MethodIndex(type=ElementType.VIR, result=results)
+    return MethodIndex(type=ElementType.VIR, software=Software.VIRFINDER, result=results)
 
 def parse_amrfinder_vir_pred(file: str):
     """Parse amrfinder virulence prediction results."""
@@ -349,4 +349,4 @@ def parse_amrfinder_vir_pred(file: str):
         hits = hits.where(pd.notnull(hits), None)
         predictions = hits[hits["element_type"] == "VIRULENCE"].to_dict(orient="records")
         results: ElementTypeResult = _parse_amrfinder_vir_results(predictions)
-    return MethodIndex(type = ElementType.VIR, result = results)
+    return MethodIndex(type = ElementType.VIR, software=Software.AMRFINDER, result = results)

--- a/bin/pipeline_result_processor/prp/parse/qc.py
+++ b/bin/pipeline_result_processor/prp/parse/qc.py
@@ -3,7 +3,7 @@
 import csv
 import logging
 
-from ..models.qc import QcMethodIndex, QcTool, QuastQcResult
+from ..models.qc import QcMethodIndex, QcSoftware, QuastQcResult
 from click.types import File
 
 LOG = logging.getLogger(__name__)
@@ -32,4 +32,4 @@ def parse_quast_results(file: File) -> QcMethodIndex:
         reference_gc=raw[0]["Reference GC (%)"],
         duplication_ratio=raw[0]["Duplication ratio"],
     )
-    return QcMethodIndex(tool=QcTool.QUAST, result=qc_res)
+    return QcMethodIndex(software=QcSoftware.QUAST, result=qc_res)

--- a/bin/pipeline_result_processor/prp/parse/species.py
+++ b/bin/pipeline_result_processor/prp/parse/species.py
@@ -11,9 +11,23 @@ SPP_MIN_READ_FRAC = 0.001
 
 def parse_kraken_result(file: str):
     """parse_species_pred""Parse species prediciton result"""
-    tax_lvl_dict = {"P": "phylum", "C": "class", "O": "order", "F": "family", "G": "genus", "S": "species"}
+    tax_lvl_dict = {
+        "P": "phylum",
+        "C": "class",
+        "O": "order",
+        "F": "family",
+        "G": "genus",
+        "S": "species",
+    }
     columns = {"name": "scientific_name"}
-    species_pred: pd.DataFrame = pd.read_csv(file, sep="\t").sort_values("fraction_total_reads", ascending=False).rename(columns = columns).replace({"taxonomy_lvl": tax_lvl_dict})
+    species_pred: pd.DataFrame = (
+        pd.read_csv(file, sep="\t")
+        .sort_values("fraction_total_reads", ascending=False)
+        .rename(columns=columns)
+        .replace({"taxonomy_lvl": tax_lvl_dict})
+    )
     # limit the number of predicted species
-    species_pred = species_pred[species_pred["fraction_total_reads"] > SPP_MIN_READ_FRAC]
+    species_pred = species_pred[
+        species_pred["fraction_total_reads"] > SPP_MIN_READ_FRAC
+    ]
     return species_pred.to_dict(orient="records")

--- a/bin/pipeline_result_processor/prp/parse/typing.py
+++ b/bin/pipeline_result_processor/prp/parse/typing.py
@@ -6,6 +6,7 @@ import logging
 
 from ..models.sample import MethodIndex
 from ..models.typing import TypingMethod, TypingResultCgMlst, TypingResultMlst
+from ..models.typing import TypingSoftware as Software
 
 LOG = logging.getLogger(__name__)
 
@@ -24,7 +25,7 @@ def parse_mlst_results(path: str) -> TypingResultMlst:
             for gene, allele in result["alleles"].items()
         },
     )
-    return MethodIndex(type=TypingMethod.MLST, result=result_obj)
+    return MethodIndex(type=TypingMethod.MLST, software=Software.MLST, result=result_obj)
 
 
 def parse_cgmlst_results(file: str, include_novel_alleles: bool = True, correct_alleles: bool = False) -> TypingResultCgMlst:
@@ -40,7 +41,7 @@ def parse_cgmlst_results(file: str, include_novel_alleles: bool = True, correct_
     ALM, alleles larger than locus length
     ASM, alleles smaller than locus length
     """
-    ERRORS = ["LNF", "PLOT3", "PLOT5", "NIPH", "NIPHEM", "ALM", "ASM"]
+    ERRORS = ("LNF", "PLOT3", "PLOT5", "NIPH", "NIPHEM", "ALM", "ASM")
 
     def replace_errors(allele):
         """Replace errors and novel alleles with nulls if they are not to be inlcuded."""
@@ -66,4 +67,4 @@ def parse_cgmlst_results(file: str, include_novel_alleles: bool = True, correct_
         n_missing=sum(1 for a in alleles if a in ERRORS),
         alleles=dict(zip(allele_names, corrected_alleles)),
     )
-    return MethodIndex(type=TypingMethod.CGMLST, result=results)
+    return MethodIndex(type=TypingMethod.CGMLST, software=Software.CHEWBBACA, result=results)

--- a/bin/pipeline_result_processor/prp/parse/typing.py
+++ b/bin/pipeline_result_processor/prp/parse/typing.py
@@ -25,10 +25,14 @@ def parse_mlst_results(path: str) -> TypingResultMlst:
             for gene, allele in result["alleles"].items()
         },
     )
-    return MethodIndex(type=TypingMethod.MLST, software=Software.MLST, result=result_obj)
+    return MethodIndex(
+        type=TypingMethod.MLST, software=Software.MLST, result=result_obj
+    )
 
 
-def parse_cgmlst_results(file: str, include_novel_alleles: bool = True, correct_alleles: bool = False) -> TypingResultCgMlst:
+def parse_cgmlst_results(
+    file: str, include_novel_alleles: bool = True, correct_alleles: bool = False
+) -> TypingResultCgMlst:
     """Parse chewbbaca cgmlst prediction results to json results.
 
     chewbbaca reports errors in allele profile, https://github.com/B-UMMI/chewBBACA
@@ -45,7 +49,14 @@ def parse_cgmlst_results(file: str, include_novel_alleles: bool = True, correct_
 
     def replace_errors(allele):
         """Replace errors and novel alleles with nulls if they are not to be inlcuded."""
-        if any([correct_alleles and allele in ERRORS, correct_alleles and allele.startswith("INF") and not include_novel_alleles]):
+        if any(
+            [
+                correct_alleles and allele in ERRORS,
+                correct_alleles
+                and allele.startswith("INF")
+                and not include_novel_alleles,
+            ]
+        ):
             return None
         elif allele.startswith("INF") and include_novel_alleles:
             return int(allele.split("-")[1])
@@ -56,7 +67,9 @@ def parse_cgmlst_results(file: str, include_novel_alleles: bool = True, correct_
         return allele
 
     msg = "Parsing cgmslt results, "
-    LOG.info(msg + "not" if not include_novel_alleles else "" + "including novel alleles")
+    LOG.info(
+        msg + "not" if not include_novel_alleles else "" + "including novel alleles"
+    )
     creader = csv.reader(file, delimiter="\t")
     _, *allele_names = (colname.rstrip(".fasta") for colname in next(creader))
     # parse alleles
@@ -67,4 +80,6 @@ def parse_cgmlst_results(file: str, include_novel_alleles: bool = True, correct_
         n_missing=sum(1 for a in alleles if a in ERRORS),
         alleles=dict(zip(allele_names, corrected_alleles)),
     )
-    return MethodIndex(type=TypingMethod.CGMLST, software=Software.CHEWBBACA, result=results)
+    return MethodIndex(
+        type=TypingMethod.CGMLST, software=Software.CHEWBBACA, result=results
+    )


### PR DESCRIPTION
Updated PRP output format to be easier to query with tools such as `jq`.

- changed `element_type_result` from a dict to a list of dicts
- added the field "software" to `MethodIndex` to improve indexing
- refactored class `QcTool` to be more similar to `MethodIndex`
- excluded empty prediction results from output