### PR TITLE
Fix code typo in prp

### DIFF
--- a/bin/pipeline_result_processor/prp/parse/phenotype.py
+++ b/bin/pipeline_result_processor/prp/parse/phenotype.py
@@ -69,7 +69,7 @@ def _parse_resfinder_amr_genes(
             coverage=info["coverage"],
             ref_start_pos=info["ref_start_pos"],
             ref_end_pos=info["ref_end_pos"],
-            ref_gene_length=info["ref_seq_lenght"],
+            ref_gene_length=info["ref_seq_length"],
             alignment_length=info["alignment_length"],
             phenotypes=info["phenotypes"],
             ref_database=info["ref_database"][0],


### PR DESCRIPTION
# Description

Fixing a wrongly spelled dictionary key that caused an error. The fix makes the workflow go through. 

## Primary function of PR
- [x] Hotfix
- [ ] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality