### PR TITLE
Fix #221: Make sure that the correct version of ResFinder is pulled, and update to 4.4.1

### DIFF
--- a/container/resfinder
+++ b/container/resfinder
@@ -30,7 +30,7 @@ From:python:3.8
          chmod -R 0777 /tmp/bestfolder
  
          pip3 install tabulate biopython cgecore gitpython python-dateutil
-         pip3 install resfinder
+         pip3 install resfinder==${RESFINDER_VERSION}
 
 
          git clone -b "${KMA_VERSION}" https://bitbucket.org/genomicepidemiology/kma.git resfinder/cge/kma && \

--- a/container/resfinder
+++ b/container/resfinder
@@ -5,14 +5,14 @@ From:python:3.8
 %labels
         MAINTAINER Isak Sylvin <isak.sylvin@gu.se>
         DESCRIPTION Singularity container for CMD microbiology WGS pipeline
-        VERSION 4.1.11
+        VERSION 4.4.1
 
 %environment
         export PATH="/tmp/bestfolder/resfinder/run_resfinder.py:$PATH"
         umask 0002
 
 %post
-     RESFINDER_VERSION=4.1.11
+     RESFINDER_VERSION=4.4.1
      KMA_VERSION=1.3.27
      BLAST_VERSION=2.9.0
 


### PR DESCRIPTION
# Description

This is a fix of #221 , where there were two related issues:

- The version of ResFinder specified in the `RESFINDER_VERSION` variable in the singularity file was not installed, but instead the last available version on PyPI. Only the git checkout was done with the correct version.
- For older versions of ResFinder, there was an issue with misspelled "length", erroneously spelled "lenght" eg for the dictionary key "ref_seq_length". This is [fixed since 4.4.0](https://bitbucket.org/genomicepidemiology/resfinder/src/master/CHANGELOG.md).

Summary of the changes made:

- The pip command is updated to include the `RESFINDER_VERSION` variable.
- The ResFinder version is bumped to 4.4.1 to fix the "lenght" typo issue.

## Primary function of PR
- [x] Hotfix
- [ ] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality

# Testing

Have re-built the resfinder images and ran the self-test.

Also checked that the correct version of resfinder was installed with:

```
singularity shell container/resfinder.sif
Singularity> python -m resfinder --version
```

I checked that it was the wrong version before (by manually forcing it to download another version available on PyPI, 4.2.0), and that it is now the correct version 4.4.1.
 
# Sign-offs
- [x] Code reviewed by @sylvinite 
- [x] Code tested by @samuell 
