### PR TITLE
Fix #238: Rename imports from get_seqrun to get_seqrun_meta

### DIFF
--- a/workflows/escherichia_coli.nf
+++ b/workflows/escherichia_coli.nf
@@ -3,7 +3,7 @@
 nextflow.enable.dsl=2
 
 include { get_meta                                  } from '../methods/get_meta'
-include { get_seqrun                                } from '../methods/get_seqrun'
+include { get_seqrun_meta                           } from '../methods/get_seqrun_meta'
 include { amrfinderplus                             } from '../nextflow-modules/modules/amrfinderplus/main'
 include { bracken                                   } from '../nextflow-modules/modules/bracken/main'
 include { bwa_index                                 } from '../nextflow-modules/modules/bwa/main'

--- a/workflows/klebsiella_pneumoniae.nf
+++ b/workflows/klebsiella_pneumoniae.nf
@@ -3,7 +3,7 @@
 nextflow.enable.dsl=2
 
 include { get_meta                                  } from '../methods/get_meta'
-include { get_seqrun                                } from '../methods/get_seqrun'
+include { get_seqrun_meta                           } from '../methods/get_seqrun_meta'
 include { amrfinderplus                             } from '../nextflow-modules/modules/amrfinderplus/main'
 include { bracken                                   } from '../nextflow-modules/modules/bracken/main'
 include { bwa_index                                 } from '../nextflow-modules/modules/bwa/main'

--- a/workflows/mycobacterium_tuberculosis.nf
+++ b/workflows/mycobacterium_tuberculosis.nf
@@ -3,7 +3,7 @@
 nextflow.enable.dsl=2
 
 include { get_meta                  } from '../methods/get_meta'
-include { get_seqrun                } from '../methods/get_seqrun'
+include { get_seqrun_meta           } from '../methods/get_seqrun_meta'
 include { bracken                   } from '../nextflow-modules/modules/bracken/main'
 include { copy_to_cron              } from '../nextflow-modules/modules/cron/main'
 include { create_analysis_result    } from '../nextflow-modules/modules/prp/main'

--- a/workflows/staphylococcus_aureus.nf
+++ b/workflows/staphylococcus_aureus.nf
@@ -3,7 +3,7 @@
 nextflow.enable.dsl=2
 
 include { get_meta                                  } from '../methods/get_meta'
-include { get_seqrun                                } from '../methods/get_seqrun'
+include { get_seqrun_meta                           } from '../methods/get_seqrun_meta'
 include { amrfinderplus                             } from '../nextflow-modules/modules/amrfinderplus/main'
 include { bracken                                   } from '../nextflow-modules/modules/bracken/main'
 include { bwa_index                                 } from '../nextflow-modules/modules/bwa/main'


### PR DESCRIPTION
# Description

See issue #238 

Renamed `get_seqrun` to `get_seqrun_meta` in multiple imports.

## Primary function of PR
- [x] Hotfix
- [ ] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality

# Testing

- Have been running the full staphylococcus_aureus workflow on 5 samples of real data, up until running into #243

# Sign-offs
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
