### PR TITLE
Fix #241: Only use part before space as ID in FASTA header

### DIFF
--- a/bin/error_corr_assembly.pl
+++ b/bin/error_corr_assembly.pl
@@ -31,7 +31,7 @@ sub read_fasta {
     while(<FA>) {
 	chomp;
 	next if /^\s*$/;
-	if( /^>(.*?)$/ ) {
+	if( /^>(.*?)(\s.*)?$/ ) {
 	    $id = $1;
 	}
 	else {


### PR DESCRIPTION
# Description

Background: See #241 

Changes: Changed the regex for picking up the FASTA header, to only take the part until the first space if there is one, to make it consistent with how the upstream tool (FreeBayes?) is creating the VCF file.

## Primary function of PR
- [x] Hotfix
- [ ] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality

# Testing

- Have been running the full staphylococcus_aureus workflow on 5 samples of real data, up until running into #243

# Sign-offs
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
