### PR TITLE
Release version 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [0.4.0]
+
+### Added
+
 - Added [tbdb](https://github.com/jodyphelan/tbdb) as a submodule.
 - Downloaded new catalogue from WHO and convert to csv required for tbdb creation using [jasentool](https://github.com/ryanjameskennedy/jasentool).
 - DB creation included using `Makefile`.

--- a/configs/nextflow.base.config
+++ b/configs/nextflow.base.config
@@ -244,5 +244,5 @@ manifest {
 	homePage = 'https://github.com/genomic-medicine-sweden/JASEN'
 	description = 'Pipeline epitypes numerous bacterial species as well as identifies AMR and virulence genes'
 	mainScript = 'main.nf'
-	version = '0.3.0'
+	version = '0.4.0'
 }

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -240,5 +240,5 @@ manifest {
 	homePage = 'https://github.com/genomic-medicine-sweden/jasen'
 	description = 'Pipeline epitypes numerous bacterial species as well as identifies AMR and virulence genes'
 	mainScript = 'main.nf'
-	version = '0.3.0'
+	version = '0.4.0'
 }

--- a/configs/nextflow.ngp.config
+++ b/configs/nextflow.ngp.config
@@ -244,5 +244,5 @@ manifest {
 	homePage = 'https://github.com/genomic-medicine-sweden/JASEN'
 	description = 'Pipeline epitypes numerous bacterial species as well as identifies AMR and virulence genes'
 	mainScript = 'main.nf'
-	version = '0.3.0'
+	version = '0.4.0'
 }

--- a/configs/nextflow.selftest.config
+++ b/configs/nextflow.selftest.config
@@ -244,5 +244,5 @@ manifest {
 	homePage = 'https://github.com/genomic-medicine-sweden/JASEN'
 	description = 'Pipeline epitypes numerous bacterial species as well as identifies AMR and virulence genes'
 	mainScript = 'main.nf'
-	version = '0.3.0'
+	version = '0.4.0'
 }


### PR DESCRIPTION
# Description

### Added

- Added [tbdb](https://github.com/jodyphelan/tbdb) as a submodule.
- Downloaded new catalogue from WHO and convert to csv required for tbdb creation using [jasentool](https://github.com/ryanjameskennedy/jasentool).
- DB creation included using `Makefile`.
- Updated configs.
- Updated `workflows/mycobacterium_tuberculosis.nf`.
- Update TBProfiler version to v5.0.1.
- Publish delly output when running tbprofiler.
- Remove Tbprofiler run using WHO database until TBProfiler issue #313 resolved.

### Fixed


### Changed

- Updated PRP to verion 0.3.0

# Sign-offs
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
