### PR TITLE
Limit CI to run only on master and dev (to be created) branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,11 @@ name: CI
 # it completes without any syntax errors
 on:
   push:
+    branches:
+      - [master, dev]
   pull_request:
     branches:
-      - master
+      - [master, dev]
 
 env:
   NXF_ANSI_LOG: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,12 @@ name: CI
 on:
   push:
     branches:
-      - [master, dev]
+      - master
+      - dev
   pull_request:
     branches:
-      - [master, dev]
+      - master
+      - dev
 
 env:
   NXF_ANSI_LOG: false


### PR DESCRIPTION
# Description

It seems the previous policy:
```yaml
on:
  push:
  pull_request:
    branches:
      - master
```

... would mean CI (Github Actions) would run on all pushes, not only on master.

This fix limits pushes to only branches `master` and `dev`, the latter of which is a suggestion for a branch to create, to use for merging together new features to run CI before merge into master.

The PR also makes sure CI runs on PRs to `dev` as well as `master`. 

## Primary function of PR
- [x] Hotfix
- [ ] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality

# Testing
- We have to verify that this works as expected after merge.

# Sign-offs
- [ ] Code reviewed by @ryanjameskennedy
- [ ] Code tested by @samuell
