### PR TITLE
Update tbprofiler to version 6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated TbProfiler to version 6.3
+
 ## [0.8.0]
 
 ### Added

--- a/configs/nextflow.dev.config
+++ b/configs/nextflow.dev.config
@@ -275,7 +275,7 @@ process {
 	withName: tbprofiler_mergedb {
 		cpus = 16
 		memory = '12 GB'
-		container = "https://depot.galaxyproject.org/singularity/tb-profiler:6.2.0--pyhdfd78af_1"
+		container = "https://depot.galaxyproject.org/singularity/tb-profiler%3A6.3.0--pyhdfd78af_0"
 		publishDir = [ [ path: "${params.outdir}/${params.speciesDir}/tbprofiler_mergedb", mode: 'copy', overwrite: true, pattern: '*.json' ], [ path: "${params.outdir}/${params.speciesDir}/${params.vcfDir}", mode: 'copy', overwrite: true, pattern: '*.{vcf.gz}' ], [ path: "${params.outdir}/${params.speciesDir}/${params.bamDir}", mode: 'copy', overwrite: true, pattern: '*.bam*' ] ]
 		ext.args = "--external_db ${params.root}/assets/tbdb/converged_who_fohm_tbdb --calling_params '-q 15'"
 	}

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -290,7 +290,7 @@ process {
 	withName: tbprofiler_mergedb {
 		cpus = 16
 		memory = '12 GB'
-		container = "https://depot.galaxyproject.org/singularity/tb-profiler:6.2.0--pyhdfd78af_1"
+		container = "https://depot.galaxyproject.org/singularity/tb-profiler%3A6.3.0--pyhdfd78af_0"
 		publishDir = [ [ path: "${params.outdir}/${params.speciesDir}/tbprofiler_mergedb", mode: 'copy', overwrite: true, pattern: '*.json' ], [ path: "${params.outdir}/${params.speciesDir}/${params.vcfDir}", mode: 'copy', overwrite: true, pattern: '*.{vcf.gz}' ], [ path: "${params.outdir}/${params.speciesDir}/${params.bamDir}", mode: 'copy', overwrite: true, pattern: '*.bam*' ] ]
 		ext.args = "--external_db ${params.root}/assets/tbdb/converged_who_fohm_tbdb --calling_params '-q 15'"
 	}

--- a/container/Makefile
+++ b/container/Makefile
@@ -66,7 +66,7 @@ URL_skesa := https://depot.galaxyproject.org/singularity/skesa:2.5.1--hdcf5f25_0
 URL_snippy := https://depot.galaxyproject.org/singularity/snippy:4.6.0--hdfd78af_2
 URL_sourmash := https://depot.galaxyproject.org/singularity/sourmash:4.8.2--hdfd78af_0
 URL_spades := https://depot.galaxyproject.org/singularity/spades:3.15.5--h95f258a_1
-URL_tb-profiler := https://depot.galaxyproject.org/singularity/tb-profiler:6.2.0--pyhdfd78af_0
+URL_tb-profiler := https://depot.galaxyproject.org/singularity/tb-profiler%3A6.3.0--pyhdfd78af_0
 URL_virulencefinder := https://depot.galaxyproject.org/singularity/virulencefinder:2.0.4--hdfd78af_1
 
 define log_message
@@ -113,4 +113,3 @@ $(local_containers):
 	&& output_file=$$(echo ${container_url} | sed -e 's#docker://##' -e 's#/#-#g' -e 's#:#-#g').img \
 	&& sudo singularity build --force $${output_file} ${container_url} \
 	&& ln -sf $${output_file} $@ 
-


### PR DESCRIPTION
# Description
This PR updates TbProfiler to version 6.3 which fixes a critical error in the resistance prediction of _Mycobacterium tuberculosis_.

_If not self-evident, mention what prompted the change._

## Primary function of PR
- [x] Hotfix
- [ ] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality

# Sign-offs
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
