### PR TITLE
Update to v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [v0.9.0]
+
+### Added
+
 - Added long-read test data (S. aureus)
 - Added `samplelist_nanopore.csv` for running long-read test data
 - Added location of documentation to `README` 

--- a/configs/nextflow.base.config
+++ b/configs/nextflow.base.config
@@ -313,5 +313,5 @@ manifest {
 	homePage = 'https://github.com/genomic-medicine-sweden/jasen'
 	description = 'Pipeline epitypes numerous bacterial species as well as identifies AMR and virulence genes'
 	mainScript = 'main.nf'
-	version = '0.8.0'
+	version = '0.9.0'
 }

--- a/configs/nextflow.ci.config
+++ b/configs/nextflow.ci.config
@@ -296,5 +296,5 @@ manifest {
 	homePage = 'https://github.com/genomic-medicine-sweden/jasen'
 	description = 'Pipeline epitypes numerous bacterial species as well as identifies AMR and virulence genes'
 	mainScript = 'main.nf'
-	version = '0.8.0'
+	version = '0.9.0'
 }

--- a/configs/nextflow.dev.config
+++ b/configs/nextflow.dev.config
@@ -296,5 +296,5 @@ manifest {
 	homePage = 'https://github.com/genomic-medicine-sweden/jasen'
 	description = 'Pipeline epitypes numerous bacterial species as well as identifies AMR and virulence genes'
 	mainScript = 'main.nf'
-	version = '0.8.0'
+	version = '0.9.0'
 }

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -165,15 +165,15 @@ process {
 		publishDir = [ [ path: "/fs1/results/cron/jasen/${params.speciesDir}", mode: 'copy', overwrite: true, pattern: '*.json' ], [ path: "/fs1/results/cron/qc", mode: 'copy', overwrite: true, pattern: '*.cdmpy' ] ]
 	}
 	withName: create_analysis_result {
-		container = "docker://clinicalgenomicslund/bonsai-prp:0.9.3"
+		container = "docker://clinicalgenomicslund/bonsai-prp:0.10.0"
 		publishDir = [ path: "${params.outdir}/${params.speciesDir}/analysis_result", mode: 'copy', overwrite: true ]
 	}
 	withName: create_cdm_input {
-		container = "docker://clinicalgenomicslund/bonsai-prp:0.9.3"
+		container = "docker://clinicalgenomicslund/bonsai-prp:0.10.0"
 		publishDir = [ path: "${params.outdir}/${params.speciesDir}/${params.cdmDir}", mode: 'copy', overwrite: true ]
 	}
 	withName: create_yaml {
-		container = "docker://clinicalgenomicslund/bonsai-prp:0.9.3"
+		container = "docker://clinicalgenomicslund/bonsai-prp:0.10.0"
 		publishDir = [ path: "${params.outdir}/${params.speciesDir}/analysis_yaml", mode: 'copy', overwrite: true ]
 		ext.args_prp = {"${params.outdir}/${params.speciesDir}/analysis_result"}
 		ext.args_sourmash = {"${params.outdir}/${params.speciesDir}/sourmash"}
@@ -223,7 +223,7 @@ process {
 	}
 	withName: post_align_qc {
 		memory = '2 GB'
-		container = "docker://clinicalgenomicslund/bonsai-prp:0.9.3"
+		container = "docker://clinicalgenomicslund/bonsai-prp:0.10.0"
 		publishDir = [ path: "${params.outdir}/${params.speciesDir}/postalignqc", mode: 'copy', overwrite: true ]
 	}
 	withName: quast {
@@ -246,7 +246,7 @@ process {
 		publishDir = [ path: "${params.outdir}/${params.speciesDir}/${params.bamDir}", mode: 'copy', overwrite: true ]
 	}
 	withName: save_analysis_metadata {
-		container = "docker://clinicalgenomicslund/bonsai-prp:0.9.3"
+		container = "docker://clinicalgenomicslund/bonsai-prp:0.10.0"
 		publishDir = [ path: "${params.outdir}/${params.speciesDir}/analysis_metadata", mode: 'copy', overwrite: true ]
 	}
 	withName: serotypefinder {
@@ -311,5 +311,5 @@ manifest {
 	homePage = 'https://github.com/genomic-medicine-sweden/jasen'
 	description = 'Pipeline epitypes numerous bacterial species as well as identifies AMR and virulence genes'
 	mainScript = 'main.nf'
-	version = '0.8.0'
+	version = '0.9.0'
 }

--- a/configs/nextflow.ngp.config
+++ b/configs/nextflow.ngp.config
@@ -321,5 +321,5 @@ manifest {
 	homePage = 'https://github.com/genomic-medicine-sweden/jasen'
 	description = 'Pipeline epitypes numerous bacterial species as well as identifies AMR and virulence genes'
 	mainScript = 'main.nf'
-	version = '0.8.0'
+	version = '0.9.0'
 }


### PR DESCRIPTION
# Description
_Summary of the changes made:_
- Added long-read test data (S. aureus)
- Added `samplelist_nanopore.csv` for running long-read test data
- Added location of documentation to `README` 
- Added `cdmDir` to config
- Added process for adding IGV annotation tracks with PRP.
- Updated how `mycobacterium_tuberculosis` workflow adds IGV annotation tracks.
- Fixed `--qc` argument filepath to be full filepath to output
- Fixed tbprofiler url in container Makefile
- Fixed TB installation steps in main Makefile
- Updated TbProfiler to version 6.3
- Updated PRP to version 0.10.0
- Removed delly annotation
- Updated vcf args in prp module

## Primary function of PR
- [x] Major functionality improvement / New type of analysis

# Testing
Tested on ecoli, saureus and tb samples
