### PR TITLE
385 enable fastqc module only for short reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed serotypefinder from saureus workflow
 - Fixed jasen running only on the first row/sample in csv
 - Fixed channel problem by changing `Channel.of([])` to `Channel.value([])`
+- Conditional running of `fastqc` module
 
 ### Changed
 

--- a/nextflow-modules/modules/fastqc/main.nf
+++ b/nextflow-modules/modules/fastqc/main.nf
@@ -3,13 +3,16 @@ process fastqc {
   scratch params.scratch
 
   input:
-    tuple val(sample_id), path(reads)
+    tuple val(sample_id), path(reads), val(platform)
 
   output:
     tuple val(sample_id), path(summary_output), emit: summary
     tuple val(sample_id), path(output)        , emit: output
     tuple val(sample_id), path(html_output)   , emit: html
     path "*versions.yml"                      , emit: versions
+
+  when:
+      platform == "illumina" || platform == "iontorrent"
 
   script:
     def args          = task.ext.args ?: ''

--- a/workflows/bacterial_base.nf
+++ b/workflows/bacterial_base.nf
@@ -97,7 +97,7 @@ workflow CALL_BACTERIAL_BASE {
         quast(ch_assembly, referenceGenome)
 
         // qc processing
-        fastqc(ch_reads)
+        fastqc(ch_reads_w_meta)
         bwa_mem_ref(ch_reads, referenceGenomeDir)
         samtools_index_ref(bwa_mem_ref.out.bam)
 


### PR DESCRIPTION
# Description

fastqc module should be activated only when analysing short reads.

_Summary of the changes made:_


## Primary function of PR
- [x] Hotfix
- [ ] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality

# Testing
Tested with illumina and nanopore test data.

# Sign-offs
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
