### PR TITLE
fix typo in Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed stub-run for S.aureus ONT workflow
+- typing error in Makefile
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -825,7 +825,7 @@ MTUBE_REFSEQ_ACC := GCF_000195955.2
 mtuberculosis_all: mtuberculosis_download_reference \
 	mtuberculosis_faidx_reference \
 	mtuberculosis_bwaidx_reference \
-	mtuberculosis_miniamp2idx_reference \
+	mtuberculosis_minimap2idx_reference \
 	mtuberculosis_converged_who_fohm_tbdb \
 	mtuberculosis_bgzip_bed \
 	mtuberculosis_index_bed


### PR DESCRIPTION
# Description
Fixed typo in Makefile, so the installation proceeds to the end.

_If not self-evident, mention what prompted the change._

_Summary of the changes made:_


## Primary function of PR
- [x] Hotfix
- [ ] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality

# Testing
_Either describe a procedure, or add data; that confirms that the PR resolves what it sets out to do_

# Sign-offs
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
