### PR TITLE
Update to v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [1.1.0]
+
+### Added
+
 - Added missing tools to S. aureus subworkflow tool list
 - Added spyogenes bed file representing cgmlst targets
 - Added `prodigal` image download to container `Makefile`

--- a/nextflow.config
+++ b/nextflow.config
@@ -359,7 +359,7 @@ manifest {
     description     = """Bacterial typing pipeline for clinical NGS data. Written in NextFlow, Python & Bash."""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=22.10.1'
-    version         = '1.0.0'
+    version         = '1.1.0'
     doi             = ''
 }
 


### PR DESCRIPTION
# Description

_Summary of the changes made:_

## [1.1.0]

### Added

- Added missing tools to S. aureus subworkflow tool list
- Added spyogenes bed file representing cgmlst targets
- Added `prodigal` image download to container `Makefile`
- Added module for mapping long reads with Minimap2
- Added Minimap2 refence index `referenceGenomeMmi` for all species
- Added `samtools_coverage` to get stats from mapping long reads to the reference and assembly
- Added `minimap2_align_assembly`
- Added `minimap2_index` for assembly indexing
- Added `when` operator to `samtools` for `nanopore`
- Added `assay` to yaml output
- Added `staphylococcus_nrl` profile
- Added `release_life_cycle` via profiles
- Added `create_prp_yaml.py` to bin
- Added `spatyper` and `sccmec` to yaml
- Added `gambitcore` as a module
- Added `apptainer` and `singularity` profiles

### Fixed

- Fixed stub-run for S.aureus ONT workflow
- Fixed typing error in Makefile
- Fixed checking out pipeline code with submodules
- Fixed genome downloading via `bin/download_ncbi.py` with timed retries
- Fixed dirty submodules in `.gitmodules`
- Fixed dubious ownership bug where finder dbs retrieve commit ID

### Changed

- Changed spyogenes genome from `GCF_000006785.2` to `GCF_005164585.1`
- Updated `check_taxon` method to include spyogenes
- Changed ptf downloading to generation of ptf via prodigal for `ecoli` & `spyogenes`
- Renamed index created by BWA from `referenceGenomeIdx` to `referenceGenomeFai`
- Renamed `bwa_mem_dedup` to `bwa_mem_assembly`
- Split `samtools_sort` into two modules
- Removed `abritamr` as it's not used
- Changed dirname `container` to `containers`
- Changed dirname `configs` to `conf`
- Changed dirname `nextflow-modules` to `modules`
- Changed importing of `spades`
- Updated `Makefile` re dir name changes
- Updated subworkflows
- Grouped most workflows into one (`bacterial_general.nf`) to remove duplicate code
- Changed to have only one main config `nexflow.config`
- Changed `cmd` module name to `cdm`
- Updated bonsai-prp to v1.3.1
- Changed indentation structure
- Moved `platform` to config via `params.platform` 
- Changed `hostile` io
- Updated docs regarding restructuring
- Changed `prp` sub commands
- Updated CI GA workflow re `container_dir`
- Removed `check-and-reinit-git-submodules` from CI GA workflow
- Removed `kma` submodule
- Updated finder submodules (`virulencefinder_db`, `resfinder_db`, `pointfinder_db`, `serotypefinder_db`)
- Updated `resfinder` version
- Changed memory allowance for hostile
- Updated docs regarding updating finder dbs

## Primary function of PR
- [x] Major functionality improvement / New type of analysis

# Testing
Tested on all species
