### PR TITLE
Update ont assembly tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed mapping settings in minimap2 from `-x map-ont` to `-x lr:hq` as quality of the data has improved
 - Updated Flye 2.9.3 to version 2.9.6
 - Updated minimap2 2.28 to version 2.30
-- Updated Medaka 2.0.1 to version 2.1.1.
+- Updated Medaka 2.0.1 to version 2.2.0
 - Updated NanoPlot 1.43.0 to 1.46.2
+- Changed container for Medaka, it includes the models, so they don't need to be downloaded while running analysis
 - Changed preset for masking of the assembly before cgMLST analysis for ONT data (default: false, as it is not tested and optimised for ONT data)
 - Changed `ch_empty` to `ch_sample_id`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -145,7 +145,7 @@ process {
         ext.when            = { params.species != "mycobacterium tuberculosis" && params.use_masking }
     }
     withName: medaka {
-        container           = (params.offline ? "${params.containers_dir}/medaka.sif" : "docker://ontresearch/medaka:sha3dc8413c2af77a427048b091c7a69b638ba30cfe")
+        container           = (params.offline ? "${params.containers_dir}/medaka.sif" : "docker://ontresearch/medaka:shacf8338462607b17b1d68dbce212cb93daea50bad")
         cpus                = (params.ci ? params.ci_cpus_max : 20)
         memory              = (params.ci ? params.ci_mem_max : '32.GB')
         time                = '2.h'

--- a/containers/Makefile
+++ b/containers/Makefile
@@ -58,7 +58,7 @@ remote_containers := ncbi-amrfinderplus.sif \
 # URLs to Docker containers
 DOCKER_bonsai-prp := docker://clinicalgenomicslund/bonsai-prp:1.5.0
 DOCKER_gambitcore := docker://clinicalgenomicslund/gambitcore:0.0.2
-DOCKER_medaka := docker://ontresearch/medaka:sha3dc8413c2af77a427048b091c7a69b638ba30cfe
+DOCKER_medaka := docker://ontresearch/medaka:shacf8338462607b17b1d68dbce212cb93daea50bad
 
 # URLs to remote containers
 URL_ncbi-amrfinderplus := https://depot.galaxyproject.org/singularity/ncbi-amrfinderplus:3.11.11--h6e70893_0

--- a/docs/source/workflows/escherichia_coli_sw.csv
+++ b/docs/source/workflows/escherichia_coli_sw.csv
@@ -9,7 +9,7 @@ freebayes,1.3.6,https://depot.galaxyproject.org/singularity/freebayes:1.3.6--hbf
 hostile,2.0.0,https://depot.galaxyproject.org/singularity/hostile:2.0.0--pyhdfd78af_0
 kraken2,2.1.2,https://depot.galaxyproject.org/singularity/kraken2:2.1.2--pl5321h9f5acd7_3
 minimiap2,2.30,https://depot.galaxyproject.org/singularity/minimap2:2.30--h577a1d6_0
-medaka,2.1.1,docker://ontresearch/medaka:sha3dc8413c2af77a427048b091c7a69b638ba30cfe
+medaka,2.2.0,docker://ontresearch/medaka:shacf8338462607b17b1d68dbce212cb93daea50bad
 mlst,2.23.0,https://depot.galaxyproject.org/singularity/mlst:2.23.0--hdfd78af_1
 nanoplot,1.46.2,https://depot.galaxyproject.org/singularity/nanoplot:1.46.2--pyhdfd78af_0
 pointfinder_db,4.0.0,https://depot.galaxyproject.org/singularity/resfinder:4.4.2--pyhdfd78af_1

--- a/docs/source/workflows/klebsiella_pneumoniae_sw.csv
+++ b/docs/source/workflows/klebsiella_pneumoniae_sw.csv
@@ -9,7 +9,7 @@ freebayes,1.3.6,https://depot.galaxyproject.org/singularity/freebayes:1.3.6--hbf
 hostile,2.0.0,https://depot.galaxyproject.org/singularity/hostile:2.0.0--pyhdfd78af_0
 kraken2,2.1.2,https://depot.galaxyproject.org/singularity/kraken2:2.1.2--pl5321h9f5acd7_3
 minimiap2,2.30,https://depot.galaxyproject.org/singularity/minimap2:2.30--h577a1d6_0
-medaka,2.1.1,docker://ontresearch/medaka:sha3dc8413c2af77a427048b091c7a69b638ba30cfe
+medaka,2.2.0,docker://ontresearch/medaka:shacf8338462607b17b1d68dbce212cb93daea50bad
 mlst,2.23.0,https://depot.galaxyproject.org/singularity/mlst:2.23.0--hdfd78af_1
 nanoplot,1.46.2,https://depot.galaxyproject.org/singularity/nanoplot:1.46.2--pyhdfd78af_0
 pointfinder_db,4.0.0,https://depot.galaxyproject.org/singularity/resfinder:4.4.2--pyhdfd78af_1

--- a/docs/source/workflows/mycobacterium_tuberculosis_sw.csv
+++ b/docs/source/workflows/mycobacterium_tuberculosis_sw.csv
@@ -4,7 +4,7 @@ bwa,0.7.17-r1188,https://depot.galaxyproject.org/singularity/bwakit:0.7.17.dev1-
 flye,2.9.6,https://depot.galaxyproject.org/singularity/flye:2.9.6--py39h475c85d_0
 hostile,2.0.0,https://depot.galaxyproject.org/singularity/hostile:2.0.0--pyhdfd78af_0
 minimiap2,2.30,https://depot.galaxyproject.org/singularity/minimap2:2.30--h577a1d6_0
-medaka,2.1.1,docker://ontresearch/medaka:sha3dc8413c2af77a427048b091c7a69b638ba30cfe
+medaka,2.2.0,docker://ontresearch/medaka:shacf8338462607b17b1d68dbce212cb93daea50bad
 mykrobe,0.12.2,https://depot.galaxyproject.org/singularity/mykrobe:0.12.2--py39h70e0db4_0
 nanoplot,1.46.2,https://depot.galaxyproject.org/singularity/nanoplot:1.46.2--pyhdfd78af_0
 prp,0.11.4,docker://clinicalgenomicslund/bonsai-prp:0.11.4

--- a/docs/source/workflows/staphylococcus_aureus_sw.csv
+++ b/docs/source/workflows/staphylococcus_aureus_sw.csv
@@ -9,7 +9,7 @@ freebayes,1.3.6,https://depot.galaxyproject.org/singularity/freebayes:1.3.6--hbf
 hostile,2.0.0,https://depot.galaxyproject.org/singularity/hostile:2.0.0--pyhdfd78af_0
 kraken2,2.1.2,https://depot.galaxyproject.org/singularity/kraken2:2.1.2--pl5321h9f5acd7_3
 minimiap2,2.30,https://depot.galaxyproject.org/singularity/minimap2:2.30--h577a1d6_0
-medaka,2.1.1,docker://ontresearch/medaka:sha3dc8413c2af77a427048b091c7a69b638ba30cfe
+medaka,2.2.0,docker://ontresearch/medaka:shacf8338462607b17b1d68dbce212cb93daea50bad
 mlst,2.23.0,https://depot.galaxyproject.org/singularity/mlst:2.23.0--hdfd78af_1
 nanoplot,1.46.2,https://depot.galaxyproject.org/singularity/nanoplot:1.46.2--pyhdfd78af_0
 pointfinder_db,4.0.0,https://depot.galaxyproject.org/singularity/resfinder:4.4.2--pyhdfd78af_1

--- a/docs/source/workflows/streptococcus_pyogenes_sw.csv
+++ b/docs/source/workflows/streptococcus_pyogenes_sw.csv
@@ -10,7 +10,7 @@ freebayes,1.3.6,https://depot.galaxyproject.org/singularity/freebayes:1.3.6--hbf
 hostile,2.0.0,https://depot.galaxyproject.org/singularity/hostile:2.0.0--pyhdfd78af_0
 kraken2,2.1.2,https://depot.galaxyproject.org/singularity/kraken2:2.1.2--pl5321h9f5acd7_3
 minimiap2,2.30,https://depot.galaxyproject.org/singularity/minimap2:2.30--h577a1d6_0
-medaka,2.1.1,docker://ontresearch/medaka:sha3dc8413c2af77a427048b091c7a69b638ba30cfe
+medaka,2.2.0,docker://ontresearch/medaka:shacf8338462607b17b1d68dbce212cb93daea50bad
 mlst,2.23.0,https://depot.galaxyproject.org/singularity/mlst:2.23.0--hdfd78af_1
 nanoplot,1.46.2,https://depot.galaxyproject.org/singularity/nanoplot:1.46.2--pyhdfd78af_0
 pointfinder_db,4.0.0,https://depot.galaxyproject.org/singularity/resfinder:4.4.2--pyhdfd78af_1

--- a/docs/source/workflows/streptococcus_sw.csv
+++ b/docs/source/workflows/streptococcus_sw.csv
@@ -10,7 +10,7 @@ freebayes,1.3.6,https://depot.galaxyproject.org/singularity/freebayes:1.3.6--hbf
 hostile,2.0.0,https://depot.galaxyproject.org/singularity/hostile:2.0.0--pyhdfd78af_0
 kraken2,2.1.2,https://depot.galaxyproject.org/singularity/kraken2:2.1.2--pl5321h9f5acd7_3
 minimiap2,2.30,https://depot.galaxyproject.org/singularity/minimap2:2.30--h577a1d6_0
-medaka,2.1.1,docker://ontresearch/medaka:sha3dc8413c2af77a427048b091c7a69b638ba30cfe
+medaka,2.2.0,docker://ontresearch/medaka:shacf8338462607b17b1d68dbce212cb93daea50bad
 mlst,2.23.0,https://depot.galaxyproject.org/singularity/mlst:2.23.0--hdfd78af_1
 nanoplot,1.46.2,https://depot.galaxyproject.org/singularity/nanoplot:1.46.2--pyhdfd78af_0
 pointfinder_db,4.0.0,https://depot.galaxyproject.org/singularity/resfinder:4.4.2--pyhdfd78af_1


### PR DESCRIPTION
# Description
_##Remove elements in cursive as needed.##_

Updated Minimap2, Flye and Medaka. 
Changed Medaka container (source: ONT dockerhub, not Galaxy) as it contains models needed to run Medaka.
Changed settings for mapping of long reads in Minimap2 to the setting that suits better nowadays quality of ONT data.

_Summary of the changes made:_


## Primary function of PR
- [ ] Hotfix
- [x] Minor functionality improvement
- [ ] Major functionality improvement / New type of analysis
- [ ] Backward-breaking functionality

# Testing
with MRSA ONT test data, as changes were only made in ONT workflow

# Sign-offs
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
