### PR TITLE
Add nanopore variant caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `clair3` import to `clair3_ref` and `freebayes` import to `freebayes_ref` in `subworkflows/variant_calling.nf` to distinguish reference-based variant calling
 - Renamed `freebayes` import to `freebayes_assembly` in `subworkflows/typing.nf` to distinguish assembly-based variant calling
 - Updated `bacterial_general.nf` to load `reference_genome_faidx` from `params.reference_genome_fai` instead of deriving it from the genome path
+- Changed `skesa`, `spades_illumina`, `spades_iontorrent`, `flye`, and `medaka` to publish to a unified `fasta/` output directory
 - Updated chewBBACA to v3.5.3 to enable use of unrestricted length of sample names
 - Updated resources in processes that read bam files
 - Removed unnecessary scripts from `bin/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added flowchart of the pipeline to the first page
 - Added details to results section of the docs
 - Added `clair3` (v2.0.0, `docker://hkubal/clair3:v2.0.0`) as the nanopore variant caller in `subworkflows/variant_calling.nf`, replacing freebayes for the nanopore platform; default model `r1041_e82_400bps_sup_v430_bacteria_finetuned`
+- Added `clair3_assembly` process to `subworkflows/typing.nf` for nanopore assembly-based variant calling when `use_masking` is enabled
+- Added `params.reference_genome_fai` to all species profiles in `nextflow.config` for explicit FAI path configuration
+- Added `samtools_faidx` process support for per-sample assembly FAI generation
 
 ### Fixed
 
@@ -31,8 +34,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `parmas.ci` typo in `mlst` `ext.when` condition in `modules.config`
 - Fixed `count_reads` output channel binding (`json` emit) in `quality_control.nf` to resolve `join` error on profiles without a reference genome (e.g. `streptococcus`)
 
+### Fixed
+
+- Fixed `error_corr_assembly.pl` to handle gzipped VCF input (`.vcf.gz`) via `gzip -dc` pipe, enabling compatibility with clair3 output
+
 ### Changed
 
+- Renamed `clair3` import to `clair3_ref` and `freebayes` import to `freebayes_ref` in `subworkflows/variant_calling.nf` to distinguish reference-based variant calling
+- Renamed `freebayes` import to `freebayes_assembly` in `subworkflows/typing.nf` to distinguish assembly-based variant calling
+- Updated `bacterial_general.nf` to load `reference_genome_faidx` from `params.reference_genome_fai` instead of deriving it from the genome path
 - Updated chewBBACA to v3.5.3 to enable use of unrestricted length of sample names
 - Updated resources in processes that read bam files
 - Removed unnecessary scripts from `bin/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `update_emmtyper_db` target to `Makefile`
 - Added flowchart of the pipeline to the first page
 - Added details to results section of the docs
-- Added `clair3` to `subworkflows/variant_calling.nf`
+- Added `clair3` (v2.0.0, `docker://hkubal/clair3:v2.0.0`) as the nanopore variant caller in `subworkflows/variant_calling.nf`, replacing freebayes for the nanopore platform; default model `r1041_e82_400bps_sup_v430_bacteria_finetuned`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `update_emmtyper_db` target to `Makefile`
 - Added flowchart of the pipeline to the first page
 - Added details to results section of the docs
+- Added `clair3` to `subworkflows/variant_calling.nf`
 
 ### Fixed
 
@@ -51,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `curl` with `wget` for emmtyper database download to avoid SSL issues
 - Updated Nextflow version in CI
 - Changed kraken2 singularity image to fetch `kraken2` + `coreutils` container from `multi-package-containers`
+- Moved variant calling for masking polymorphisms before cgmlst typing to `subworkflows/typing.nf`
 
 ## [1.2.0]
 

--- a/bin/error_corr_assembly.pl
+++ b/bin/error_corr_assembly.pl
@@ -44,7 +44,11 @@ sub read_fasta {
 
 sub read_vcf {
     my $fn = shift;
-    open( VCF, $fn );
+    if ($fn =~ /\.gz$/) {
+        open( VCF, "gzip -dc $fn |" ) or die "Cannot open $fn: $!";
+    } else {
+        open( VCF, $fn ) or die "Cannot open $fn: $!";
+    }
     my %sites;
     while(<VCF>) {
 	chomp;

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -154,7 +154,7 @@ process {
         container           = (params.offline ? "${params.containers_dir}/freebayes.sif" : "https://depot.galaxyproject.org/singularity/freebayes:1.3.6--hbfe0e7f_2")
         publishDir          = [ path: "${params.outdir}/${params.species_dir}/${params.vcf_dir}", mode: 'copy', overwrite: true ]
         ext.args            = "-C 2 -F 0.2 --pooled-continuous"
-        ext.when            = { params.species != "mycobacterium tuberculosis" && params.platform != "nanopore" }
+        ext.when            = { params.species != "mycobacterium tuberculosis" }
     }
     withName: gambitcore {
         cpus                = 4

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -35,7 +35,7 @@ process {
         ext.args            = "-r 150"
         ext.when            = { params.use_kraken }
     }
-    withName: clair3 {
+    withName: clair3_ref {
         time                = '4.h'
         cpus                = (params.ci ? params.ci_cpus_max : 8)
         memory              = (params.ci ? params.ci_mem_max : '16.GB')
@@ -43,6 +43,14 @@ process {
         publishDir          = [ path: "${params.outdir}/${params.species_dir}/${params.vcf_dir}", mode: 'copy', overwrite: true ]
         ext.platform        = "ont"
         ext.when            = { params.platform == "nanopore" && params.species != "mycobacterium tuberculosis" }
+    }
+    withName: clair3_assembly {
+        time                = '4.h'
+        cpus                = (params.ci ? params.ci_cpus_max : 8)
+        memory              = (params.ci ? params.ci_mem_max : '16.GB')
+        container           = (params.offline ? "${params.containers_dir}/clair3.sif" : "docker://hkubal/clair3:v2.0.0")
+        ext.platform        = "ont"
+        ext.when            = { params.platform == "nanopore" && params.use_masking && params.species != "mycobacterium tuberculosis" }
     }
     withName: bwa_index {
         cpus                = 2
@@ -147,7 +155,7 @@ process {
         container           = (params.offline ? "${params.containers_dir}/bonsai-prp.sif" : "docker://clinicalgenomicslund/bonsai-prp:1.6.1")
         publishDir          = [ path: "${params.outdir}/${params.species_dir}/analysis_result", mode: 'copy', overwrite: true ]
     }
-    withName: freebayes {
+    withName: freebayes_ref {
         time                = 4.h
         cpus                = 4
         memory              = '8.GB'
@@ -155,6 +163,14 @@ process {
         publishDir          = [ path: "${params.outdir}/${params.species_dir}/${params.vcf_dir}", mode: 'copy', overwrite: true ]
         ext.args            = "-C 2 -F 0.2 --pooled-continuous"
         ext.when            = { params.species != "mycobacterium tuberculosis" }
+    }
+    withName: freebayes_assembly {
+        time                = 4.h
+        cpus                = 4
+        memory              = '8.GB'
+        container           = (params.offline ? "${params.containers_dir}/freebayes.sif" : "https://depot.galaxyproject.org/singularity/freebayes:1.3.6--hbfe0e7f_2")
+        ext.args            = "-C 2 -F 0.2 --pooled-continuous"
+        ext.when            = { params.use_masking && params.species != "mycobacterium tuberculosis" }
     }
     withName: gambitcore {
         cpus                = 4
@@ -269,6 +285,12 @@ process {
         publishDir          = [ path: "${params.outdir}/${params.species_dir}/resfinder", mode: 'copy', overwrite: true ]
         ext.nanopore_args   = (params.platform == "nanopore" ? "--nanopore --ignore_indels --ignore_stop_codons" : "")
         ext.when            = { params.species != "mycobacterium tuberculosis" }
+    }
+    withName: samtools_faidx_assembly {
+        cpus                = 2
+        memory              = '2.GB'
+        container           = (params.offline ? "${params.containers_dir}/samtools.sif" : "https://depot.galaxyproject.org/singularity/samtools:1.17--h00cdaf9_0")
+        ext.when            = { params.species != "mycobacterium tuberculosis" && params.platform == "nanopore" && params.use_masking }
     }
     withName: samtools_coverage {
         cpus                = 2

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -35,6 +35,14 @@ process {
         ext.args            = "-r 150"
         ext.when            = { params.use_kraken }
     }
+    withName: clair3_assembly {
+        time                = '4.h'
+        cpus                = (params.ci ? params.ci_cpus_max : 8)
+        memory              = (params.ci ? params.ci_mem_max : '16.GB')
+        container           = (params.offline ? "${params.containers_dir}/clair3.sif" : "docker://hkubal/clair3:v2.0.0")
+        ext.platform        = "ont"
+        ext.when            = { params.platform == "nanopore" && params.use_masking && params.species != "mycobacterium tuberculosis" }
+    }
     withName: clair3_ref {
         time                = '4.h'
         cpus                = (params.ci ? params.ci_cpus_max : 8)
@@ -43,14 +51,6 @@ process {
         publishDir          = [ path: "${params.outdir}/${params.species_dir}/${params.vcf_dir}", mode: 'copy', overwrite: true ]
         ext.platform        = "ont"
         ext.when            = { params.platform == "nanopore" && params.species != "mycobacterium tuberculosis" }
-    }
-    withName: clair3_assembly {
-        time                = '4.h'
-        cpus                = (params.ci ? params.ci_cpus_max : 8)
-        memory              = (params.ci ? params.ci_mem_max : '16.GB')
-        container           = (params.offline ? "${params.containers_dir}/clair3.sif" : "docker://hkubal/clair3:v2.0.0")
-        ext.platform        = "ont"
-        ext.when            = { params.platform == "nanopore" && params.use_masking && params.species != "mycobacterium tuberculosis" }
     }
     withName: bwa_index {
         cpus                = 2
@@ -138,7 +138,7 @@ process {
         cpus                = (params.ci ? params.ci_cpus_max : 20)
         memory              = (params.ci ? params.ci_mem_max : '32.GB')
         container           = (params.offline ? "${params.containers_dir}/flye.sif" : "https://depot.galaxyproject.org/singularity/flye:2.9.6--py39h475c85d_0")
-        publishDir          = [ path: "${params.outdir}/${params.species_dir}/flye", mode: 'copy', overwrite: true ]
+        publishDir          = [ path: "${params.outdir}/${params.species_dir}/fasta", mode: 'copy', overwrite: true ]
         ext.args            = (params.reference_size ? "--genome-size ${params.reference_size} --asm-coverage 50" : "--asm-coverage 50")
         ext.seqmethod       = "--nano-hq"
         ext.when            = { params.platform == "nanopore" }
@@ -155,6 +155,14 @@ process {
         container           = (params.offline ? "${params.containers_dir}/bonsai-prp.sif" : "docker://clinicalgenomicslund/bonsai-prp:1.6.1")
         publishDir          = [ path: "${params.outdir}/${params.species_dir}/analysis_result", mode: 'copy', overwrite: true ]
     }
+    withName: freebayes_assembly {
+        time                = 4.h
+        cpus                = 4
+        memory              = '8.GB'
+        container           = (params.offline ? "${params.containers_dir}/freebayes.sif" : "https://depot.galaxyproject.org/singularity/freebayes:1.3.6--hbfe0e7f_2")
+        ext.args            = "-C 2 -F 0.2 --pooled-continuous"
+        ext.when            = { params.use_masking && params.species != "mycobacterium tuberculosis" }
+    }
     withName: freebayes_ref {
         time                = 4.h
         cpus                = 4
@@ -163,14 +171,6 @@ process {
         publishDir          = [ path: "${params.outdir}/${params.species_dir}/${params.vcf_dir}", mode: 'copy', overwrite: true ]
         ext.args            = "-C 2 -F 0.2 --pooled-continuous"
         ext.when            = { params.species != "mycobacterium tuberculosis" }
-    }
-    withName: freebayes_assembly {
-        time                = 4.h
-        cpus                = 4
-        memory              = '8.GB'
-        container           = (params.offline ? "${params.containers_dir}/freebayes.sif" : "https://depot.galaxyproject.org/singularity/freebayes:1.3.6--hbfe0e7f_2")
-        ext.args            = "-C 2 -F 0.2 --pooled-continuous"
-        ext.when            = { params.use_masking && params.species != "mycobacterium tuberculosis" }
     }
     withName: gambitcore {
         cpus                = 4
@@ -219,7 +219,7 @@ process {
         cpus                = (params.ci ? params.ci_cpus_max : 20)
         memory              = (params.ci ? params.ci_mem_max : '32.GB')
         container           = (params.offline ? "${params.containers_dir}/medaka.sif" : "docker://ontresearch/medaka:shacf8338462607b17b1d68dbce212cb93daea50bad")
-        publishDir          = [ path: "${params.outdir}/${params.species_dir}/medaka", mode: 'copy', overwrite: true ]
+        publishDir          = [ path: "${params.outdir}/${params.species_dir}/fasta", mode: 'copy', overwrite: true ]
         ext.args            = "-t 40 --bacteria"
         ext.when            = { params.platform == "nanopore" }
     }
@@ -286,17 +286,17 @@ process {
         ext.nanopore_args   = (params.platform == "nanopore" ? "--nanopore --ignore_indels --ignore_stop_codons" : "")
         ext.when            = { params.species != "mycobacterium tuberculosis" }
     }
-    withName: samtools_faidx_assembly {
-        cpus                = 2
-        memory              = '2.GB'
-        container           = (params.offline ? "${params.containers_dir}/samtools.sif" : "https://depot.galaxyproject.org/singularity/samtools:1.17--h00cdaf9_0")
-        ext.when            = { params.species != "mycobacterium tuberculosis" && params.platform == "nanopore" && params.use_masking }
-    }
     withName: samtools_coverage {
         cpus                = 2
         memory              = '2.GB'
         container           = (params.offline ? "${params.containers_dir}/samtools.sif" : "https://depot.galaxyproject.org/singularity/samtools:1.17--h00cdaf9_0")
         publishDir          = [ path: "${params.outdir}/${params.species_dir}/coverage", mode: 'copy', overwrite: true ]
+    }
+    withName: samtools_faidx_assembly {
+        cpus                = 2
+        memory              = '2.GB'
+        container           = (params.offline ? "${params.containers_dir}/samtools.sif" : "https://depot.galaxyproject.org/singularity/samtools:1.17--h00cdaf9_0")
+        ext.when            = { params.species != "mycobacterium tuberculosis" && params.platform == "nanopore" && params.use_masking }
     }
     withName: samtools_index_assembly {
         cpus                = (params.ci ? params.ci_cpus_max : 16)
@@ -370,7 +370,7 @@ process {
         cpus                = (params.ci ? params.ci_cpus_max : 16)
         memory              = (params.ci ? params.ci_mem_max : '32.GB')
         container           = (params.offline ? "${params.containers_dir}/skesa.sif" : "https://depot.galaxyproject.org/singularity/skesa:2.4.0--he1c1bb9_0")
-        publishDir          = [ path: "${params.outdir}/${params.species_dir}/skesa", mode: 'copy', overwrite: true ]
+        publishDir          = [ path: "${params.outdir}/${params.species_dir}/fasta", mode: 'copy', overwrite: true ]
         ext.when            = { params.use_skesa && params.platform == "illumina" }
     }
     withName: snippy {
@@ -391,7 +391,7 @@ process {
         cpus                = (params.ci ? params.ci_cpus_max : 16)
         memory              = (params.ci ? params.ci_mem_max : '15.GB')
         container           = (params.offline ? "${params.containers_dir}/spades.sif" : "https://depot.galaxyproject.org/singularity/spades:3.15.5--h95f258a_1")
-        publishDir          = [ path: "${params.outdir}/${params.species_dir}/spades_illumina", mode: 'copy', overwrite: true ]
+        publishDir          = [ path: "${params.outdir}/${params.species_dir}/fasta", mode: 'copy', overwrite: true ]
         ext.args            = "--isolate"
         ext.when            = { !params.use_skesa && params.platform == "illumina" }
     }
@@ -399,7 +399,7 @@ process {
         cpus                = (params.ci ? params.ci_cpus_max : 16)
         memory              = (params.ci ? params.ci_mem_max : '15.GB')
         container           = (params.offline ? "${params.containers_dir}/spades.sif" : "https://depot.galaxyproject.org/singularity/spades:3.15.5--h95f258a_1")
-        publishDir          = [ path: "${params.outdir}/${params.species_dir}/spades_iontorrent", mode: 'copy', overwrite: true ]
+        publishDir          = [ path: "${params.outdir}/${params.species_dir}/fasta", mode: 'copy', overwrite: true ]
         ext.args            = "--iontorrent --careful --sc"
         ext.when            = { params.platform == "iontorrent" }
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -35,6 +35,15 @@ process {
         ext.args            = "-r 150"
         ext.when            = { params.use_kraken }
     }
+    withName: clair3 {
+        time                = '4.h'
+        cpus                = (params.ci ? params.ci_cpus_max : 8)
+        memory              = (params.ci ? params.ci_mem_max : '16.GB')
+        container           = (params.offline ? "${params.containers_dir}/clair3.sif" : "docker://hkubal/clair3:v2.0.0")
+        publishDir          = [ path: "${params.outdir}/${params.species_dir}/${params.vcf_dir}", mode: 'copy', overwrite: true ]
+        ext.platform        = "ont"
+        ext.when            = { params.platform == "nanopore" && params.species != "mycobacterium tuberculosis" }
+    }
     withName: bwa_index {
         cpus                = 2
         memory              = '2.GB'
@@ -145,7 +154,7 @@ process {
         container           = (params.offline ? "${params.containers_dir}/freebayes.sif" : "https://depot.galaxyproject.org/singularity/freebayes:1.3.6--hbfe0e7f_2")
         publishDir          = [ path: "${params.outdir}/${params.species_dir}/${params.vcf_dir}", mode: 'copy', overwrite: true ]
         ext.args            = "-C 2 -F 0.2 --pooled-continuous"
-        ext.when            = { params.species != "mycobacterium tuberculosis" && params.use_masking }
+        ext.when            = { params.species != "mycobacterium tuberculosis" && params.platform != "nanopore" }
     }
     withName: gambitcore {
         cpus                = 4

--- a/containers/Makefile
+++ b/containers/Makefile
@@ -15,6 +15,7 @@ all: \
 # These are containers that will be built locally using the definition files in
 # the current folder
 local_containers := bonsai-prp.sif \
+					clair3.sif \
 					gambitcore.sif \
 					jasentool.sif \
 					medaka.sif
@@ -59,6 +60,7 @@ remote_containers := ncbi-amrfinderplus.sif \
 
 # URLs to Docker containers
 DOCKER_bonsai-prp := docker://clinicalgenomicslund/bonsai-prp:1.6.1
+DOCKER_clair3 := docker://hkubal/clair3:v2.0.0
 DOCKER_gambitcore := docker://clinicalgenomicslund/gambitcore:0.0.2
 DOCKER_jasentool := docker://clinicalgenomicslund/jasentool:1.0.0
 DOCKER_medaka := docker://ontresearch/medaka:shacf8338462607b17b1d68dbce212cb93daea50bad

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -88,6 +88,8 @@ Source: `nextflow.config`
 
 When analysing Nanopore data:
 * Edit the `ext.seqmethod` in `conf/modules.config` for Flye in case you are using older ONT data (default: --nano-hq, suitable for ONT data generated with R10 chemistry)
+* `params.clair3_model` in `nextflow.config` is set to  `r1041_e82_400bps_sup_v430_bacteria_finetuned`, but can be changed to [any other available model](https://github.com/HKU-BAL/Clair3#pre-trained-models)
+* Medaka is recognising basecalling model automatically and using bacterial model for polishing of the assembly, but this can be changed in `conf/modules.config` (edit `ext.args` for a process named `medaka`)
 
 ### Test data
 Source: `assets/test_data/samplelist*.csv`

--- a/docs/source/workflows/escherichia_coli_sw.csv
+++ b/docs/source/workflows/escherichia_coli_sw.csv
@@ -3,6 +3,7 @@ amrfinderplus,4.2.7,https://depot.galaxyproject.org/singularity/ncbi-amrfinderpl
 bracken,2.8,https://depot.galaxyproject.org/singularity/bracken:2.8--py39hc16433a_0
 bwa,0.7.17-r1188,https://depot.galaxyproject.org/singularity/bwakit:0.7.17.dev1--hdfd78af_1
 chewbbaca,3.5.3,https://depot.galaxyproject.org/singularity/chewbbaca:3.5.3--pyh106432d_1
+clair3,2.0.0,docker://hkubal/clair3:v2.0.0
 fastqc,0.12.1,https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0
 filtlong,0.3.1,https://depot.galaxyproject.org/singularity/filtlong:0.3.1--h077b44d_0
 flye,2.9.6,https://depot.galaxyproject.org/singularity/flye:2.9.6--py39h475c85d_0

--- a/docs/source/workflows/klebsiella_sw.csv
+++ b/docs/source/workflows/klebsiella_sw.csv
@@ -3,6 +3,7 @@ amrfinderplus,4.2.7,https://depot.galaxyproject.org/singularity/ncbi-amrfinderpl
 bracken,2.8,https://depot.galaxyproject.org/singularity/bracken:2.8--py39hc16433a_0
 bwa,0.7.17-r1188,https://depot.galaxyproject.org/singularity/bwakit:0.7.17.dev1--hdfd78af_1
 chewbbaca,3.5.3,https://depot.galaxyproject.org/singularity/chewbbaca:3.5.3--pyh106432d_1
+clair3,2.0.0,docker://hkubal/clair3:v2.0.0
 fastqc,0.12.1,https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0
 filtlong,0.3.1,https://depot.galaxyproject.org/singularity/filtlong:0.3.1--h077b44d_0
 flye,2.9.6,https://depot.galaxyproject.org/singularity/flye:2.9.6--py39h475c85d_0

--- a/docs/source/workflows/staphylococcus_aureus_sw.csv
+++ b/docs/source/workflows/staphylococcus_aureus_sw.csv
@@ -3,6 +3,7 @@ amrfinderplus,4.2.7,https://depot.galaxyproject.org/singularity/ncbi-amrfinderpl
 bracken,2.8,https://depot.galaxyproject.org/singularity/bracken:2.8--py39hc16433a_0
 bwa,0.7.17-r1188,https://depot.galaxyproject.org/singularity/bwakit:0.7.17.dev1--hdfd78af_1
 chewbbaca,3.5.3,https://depot.galaxyproject.org/singularity/chewbbaca:3.5.3--pyh106432d_1
+clair3,2.0.0,docker://hkubal/clair3:v2.0.0
 fastqc,0.12.1,https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0
 filtlong,0.3.1,https://depot.galaxyproject.org/singularity/filtlong:0.3.1--h077b44d_0
 flye,2.9.6,https://depot.galaxyproject.org/singularity/flye:2.9.6--py39h475c85d_0

--- a/docs/source/workflows/streptococcus_pyogenes_sw.csv
+++ b/docs/source/workflows/streptococcus_pyogenes_sw.csv
@@ -3,6 +3,7 @@ amrfinderplus,4.2.7,https://depot.galaxyproject.org/singularity/ncbi-amrfinderpl
 bracken,2.8,https://depot.galaxyproject.org/singularity/bracken:2.8--py39hc16433a_0
 bwa,0.7.17-r1188,https://depot.galaxyproject.org/singularity/bwakit:0.7.17.dev1--hdfd78af_1
 chewbbaca,3.5.3,https://depot.galaxyproject.org/singularity/chewbbaca:3.5.3--pyh106432d_1
+clair3,2.0.0,docker://hkubal/clair3:v2.0.0
 emmtyper,0.2.0,https://depot.galaxyproject.org/singularity/emmtyper:0.2.0--py_0
 fastqc,0.12.1,https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0
 filtlong,0.3.1,https://depot.galaxyproject.org/singularity/filtlong:0.3.1--h077b44d_0

--- a/docs/source/workflows/streptococcus_sw.csv
+++ b/docs/source/workflows/streptococcus_sw.csv
@@ -3,6 +3,7 @@ amrfinderplus,4.2.7,https://depot.galaxyproject.org/singularity/ncbi-amrfinderpl
 bracken,2.8,https://depot.galaxyproject.org/singularity/bracken:2.8--py39hc16433a_0
 bwa,0.7.17-r1188,https://depot.galaxyproject.org/singularity/bwakit:0.7.17.dev1--hdfd78af_1
 chewbbaca,3.5.3,https://depot.galaxyproject.org/singularity/chewbbaca:3.5.3--pyh106432d_1
+clair3,2.0.0,docker://hkubal/clair3:v2.0.0
 emmtyper,0.2.0,https://depot.galaxyproject.org/singularity/emmtyper:0.2.0--py_0
 fastqc,0.12.1,https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0
 filtlong,0.3.1,https://depot.galaxyproject.org/singularity/filtlong:0.3.1--h077b44d_0

--- a/modules/nf-core/clair3/main.nf
+++ b/modules/nf-core/clair3/main.nf
@@ -22,15 +22,15 @@ process clair3 {
     output = "${sample_id}_clair3.vcf.gz"
     """
     run_clair3.sh \\
-        --bam_fn=${bam} \\
-        --ref_fn=${reference} \\
+        --bam_fn=\${PWD}/${bam} \\
+        --ref_fn=\${PWD}/${reference} \\
         --threads=${task.cpus} \\
         --platform=${platform} \\
         --model_path=${model_path} \\
-        --output=clair3_output \\
+        --output=. \\
         ${args}
 
-    cp clair3_output/merge_output.vcf.gz ${output}
+    mv merge_output.vcf.gz ${output}
 
     cat <<-END_VERSIONS > ${sample_id}_${task.process}_versions.yml
     ${task.process}:

--- a/modules/nf-core/clair3/main.nf
+++ b/modules/nf-core/clair3/main.nf
@@ -1,0 +1,55 @@
+process clair3 {
+    tag "${sample_id}"
+    scratch params.scratch
+
+    input:
+    tuple val(sample_id), path(bam), path(bai)
+    path reference
+    path reference_fai
+    val model
+
+    output:
+    tuple val(sample_id), path("${sample_id}_clair3.vcf.gz"), emit: vcf
+    path "*versions.yml"                                     , emit: versions
+
+    when:
+    task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def platform = task.ext.platform ?: 'ont'
+    def model_path = model.toString().startsWith('/') ? model : "/opt/models/${model}"
+    output = "${sample_id}_clair3.vcf.gz"
+    """
+    run_clair3.sh \\
+        --bam_fn=${bam} \\
+        --ref_fn=${reference} \\
+        --threads=${task.cpus} \\
+        --platform=${platform} \\
+        --model_path=${model_path} \\
+        --output=clair3_output \\
+        ${args}
+
+    cp clair3_output/merge_output.vcf.gz ${output}
+
+    cat <<-END_VERSIONS > ${sample_id}_${task.process}_versions.yml
+    ${task.process}:
+     clair3:
+      version: \$(run_clair3.sh --version 2>&1 | sed 's/Clair3 v//')
+      container: ${task.container}
+    END_VERSIONS
+    """
+
+    stub:
+    output = "${sample_id}_clair3.vcf.gz"
+    """
+    touch ${output}
+
+    cat <<-END_VERSIONS > ${sample_id}_${task.process}_versions.yml
+    ${task.process}:
+     clair3:
+      version: \$(run_clair3.sh --version 2>&1 | sed 's/Clair3 v//')
+      container: ${task.container}
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/samtools/main.nf
+++ b/modules/nf-core/samtools/main.nf
@@ -126,20 +126,20 @@ process samtools_index {
 }
 
 process samtools_faidx {
-    tag "${input}"
+    tag "${sample_id}"
     scratch params.scratch
 
     input:
-    path input
+    tuple val(sample_id), path(fasta)
 
     output:
-    path output         , emit: fai
-    path "*versions.yml", emit: versions
+    tuple val(sample_id), path(output), emit: fai
+    path "*versions.yml"              , emit: versions
 
     script:
-    output = "${input}.fai"
+    output = "${fasta}.fai"
     """
-    samtools faidx ${input}
+    samtools faidx ${fasta}
 
     cat <<-END_VERSIONS > ${sample_id}_${task.process}_versions.yml
     ${task.process}:
@@ -150,7 +150,7 @@ process samtools_faidx {
     """
 
     stub:
-    output = "${input}.fai"
+    output = "${fasta}.fai"
     """
     touch ${output}
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -158,6 +158,7 @@ profiles {
         params.assay                = 'saureus'
         params.mlst_scheme          = 'saureus'
         params.reference_genome     = "${projectDir}/assets/genomes/staphylococcus_aureus/GCF_000012045.1.fasta"
+        params.reference_genome_fai = "${projectDir}/assets/genomes/staphylococcus_aureus/GCF_000012045.1.fasta.fai"
         params.reference_genome_idx = "${projectDir}/assets/genomes/staphylococcus_aureus/GCF_000012045.1.${params.idx_ext}"
         params.reference_genome_gff = "${projectDir}/assets/genomes/staphylococcus_aureus/GCF_000012045.1.gff"
         params.reference_size       = "2.8m"
@@ -177,6 +178,7 @@ profiles {
         params.assay                = 'ecoli'
         params.mlst_scheme          = 'ecoli_achtman_4'
         params.reference_genome     = "${projectDir}/assets/genomes/escherichia_coli/GCF_000005845.2.fasta"
+        params.reference_genome_fai = "${projectDir}/assets/genomes/escherichia_coli/GCF_000005845.2.fasta.fai"
         params.reference_genome_idx = "${projectDir}/assets/genomes/escherichia_coli/GCF_000005845.2.${params.idx_ext}"
         params.reference_genome_gff = "${projectDir}/assets/genomes/escherichia_coli/GCF_000005845.2.gff"
         params.reference_size       = "4.6m"
@@ -201,6 +203,7 @@ profiles {
         params.resistant_loci_name  = 'resistance_loci'
         params.grading_loci_name    = 'grading_loci'
         params.reference_genome     = "${projectDir}/assets/genomes/mycobacterium_tuberculosis/GCF_000195955.2.fasta"
+        params.reference_genome_fai = "${projectDir}/assets/genomes/mycobacterium_tuberculosis/GCF_000195955.2.fasta.fai"
         params.reference_genome_idx = "${projectDir}/assets/genomes/mycobacterium_tuberculosis/GCF_000195955.2.${params.idx_ext}"
         params.reference_genome_gff = "${projectDir}/assets/genomes/mycobacterium_tuberculosis/GCF_000195955.2.gff"
         params.reference_size       = "4.4m"
@@ -218,6 +221,7 @@ profiles {
         params.assay                = 'spyogenes'
         params.mlst_scheme          = 'spyogenes'
         params.reference_genome     = "${projectDir}/assets/genomes/streptococcus_pyogenes/GCF_005164585.1.fasta"
+        params.reference_genome_fai = "${projectDir}/assets/genomes/streptococcus_pyogenes/GCF_005164585.1.fasta.fai"
         params.reference_genome_idx = "${projectDir}/assets/genomes/streptococcus_pyogenes/GCF_005164585.1.${params.idx_ext}"
         params.reference_genome_gff = "${projectDir}/assets/genomes/streptococcus_pyogenes/GCF_005164585.1.gff"
         params.reference_size       = "1.8m"
@@ -233,6 +237,7 @@ profiles {
         params.assay                = 'streptococcus'
         params.mlst_scheme          = null
         params.reference_genome     = null
+        params.reference_genome_fai = null
         params.reference_genome_idx = null
         params.reference_genome_gff = null
         params.reference_size       = null
@@ -248,6 +253,7 @@ profiles {
         params.assay                = 'staphylococcus'
         params.mlst_scheme          = null
         params.reference_genome     = "${projectDir}/assets/genomes/staphylococcus_aureus/GCF_000012045.1.fasta"
+        params.reference_genome_fai = "${projectDir}/assets/genomes/staphylococcus_aureus/GCF_000012045.1.fasta.fai"
         params.reference_genome_idx = "${projectDir}/assets/genomes/staphylococcus_aureus/GCF_000012045.1.${params.idx_ext}"
         params.reference_genome_gff = "${projectDir}/assets/genomes/staphylococcus_aureus/GCF_000012045.1.gff"
         params.reference_size       = null
@@ -264,6 +270,7 @@ profiles {
         params.assay                = 'klebsiella'
         params.mlst_scheme          = 'klebsiella'
         params.reference_genome     = "${projectDir}/assets/genomes/klebsiella_pneumoniae/GCF_000240185.1.fasta"
+        params.reference_genome_fai = "${projectDir}/assets/genomes/klebsiella_pneumoniae/GCF_000240185.1.fasta.fai"
         params.reference_genome_idx = "${projectDir}/assets/genomes/klebsiella_pneumoniae/GCF_000240185.1.${params.idx_ext}"
         params.reference_genome_gff = "${projectDir}/assets/genomes/klebsiella_pneumoniae/GCF_000240185.1.gff"
         params.reference_size       = "5.7m"

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,6 +49,10 @@ params {
     tbdb                    = ""
     virulencefinder_db      = "${projectDir}/assets/virulencefinder_db"
 
+    // Models //
+
+    clair3_model         = null
+
     // Pipeline options //
 
     copy_to_cron            = false
@@ -125,6 +129,7 @@ profiles {
         params.hostile_idx          = "human-t2t-hla.fa.gz"
         params.hostile_args         = "--airplane --aligner minimap2"
         params.use_masking          = false // Masking has not been tested for long-reads
+        params.clair3_model         = "r1041_e82_400bps_sup_v430_bacteria_finetuned"
     }
 
     iontorrent {

--- a/subworkflows/typing.nf
+++ b/subworkflows/typing.nf
@@ -7,7 +7,9 @@ include { bwa_mem as bwa_mem_assembly               } from '../modules/nf-core/b
 include { chewbbaca_allelecall                      } from '../modules/nf-core/chewbbaca/main.nf'
 include { chewbbaca_split_results                   } from '../modules/local/chewbbaca/split/main.nf'
 include { emmtyper                                  } from '../modules/nf-core/emmtyper/main.nf'
-include { freebayes                                 } from '../modules/nf-core/freebayes/main.nf'
+include { clair3 as clair3_assembly                 } from '../modules/nf-core/clair3/main.nf'
+include { freebayes as freebayes_assembly           } from '../modules/nf-core/freebayes/main.nf'
+include { samtools_faidx as samtools_faidx_assembly } from '../modules/nf-core/samtools/main.nf'
 include { minimap2_align as minimap2_align_assembly } from '../modules/nf-core/minimap2/main.nf'
 include { minimap2_index                            } from '../modules/nf-core/minimap2/main.nf'
 include { mlst                                      } from '../modules/nf-core/mlst/main.nf'
@@ -22,6 +24,7 @@ include { spatyper                                  } from '../modules/nf-core/s
 workflow CALL_TYPING {
     take:
     chewbbaca_db
+    clair3_model
     mlst_blast_db
     mlst_scheme
     pubmlst_db
@@ -78,15 +81,32 @@ workflow CALL_TYPING {
             .join(samtools_index_assembly.out.bai)
             .set{ ch_assembly_bam_bai }
 
-        freebayes(ch_assembly.join(ch_assembly_bam_bai)).vcf.set{ ch_polymorph_vcf }
-
         ch_versions = ch_versions.mix(bwa_index.out.versions)
         ch_versions = ch_versions.mix(bwa_mem_assembly.out.versions)
-        ch_versions = ch_versions.mix(freebayes.out.versions)
         ch_versions = ch_versions.mix(minimap2_align_assembly.out.versions)
         ch_versions = ch_versions.mix(minimap2_index.out.versions)
         ch_versions = ch_versions.mix(samtools_index_assembly.out.versions)
         ch_versions = ch_versions.mix(samtools_sort_assembly.out.versions)
+
+        if ( params.platform == "nanopore" ) {
+            samtools_faidx_assembly(ch_assembly)
+            ch_versions = ch_versions.mix(samtools_faidx_assembly.out.versions)
+
+            ch_assembly_bam_bai
+                .join(ch_assembly)
+                .join(samtools_faidx_assembly.out.fai)
+                .multiMap { id, bam, bai, fasta, fai ->
+                    bam_bai:       tuple(id, bam, bai)
+                    fasta:     fasta
+                    fasta_fai: fai
+                }
+                .set { ch_clair3_assembly_in }
+            clair3_assembly(ch_clair3_assembly_in.bam_bai, ch_clair3_assembly_in.fasta, ch_clair3_assembly_in.fasta_fai, clair3_model).vcf.set{ ch_polymorph_vcf }
+            ch_versions = ch_versions.mix(clair3_assembly.out.versions)
+        } else {
+            freebayes_assembly(ch_assembly.join(ch_assembly_bam_bai)).vcf.set{ ch_polymorph_vcf }
+            ch_versions = ch_versions.mix(freebayes_assembly.out.versions)
+        }
 
         mask_polymorph_assembly(ch_assembly.join(ch_polymorph_vcf))
 

--- a/subworkflows/typing.nf
+++ b/subworkflows/typing.nf
@@ -2,15 +2,22 @@
 
 nextflow.enable.dsl=2
 
-include { chewbbaca_allelecall          } from '../modules/nf-core/chewbbaca/main.nf'
-include { chewbbaca_split_results       } from '../modules/local/chewbbaca/split/main.nf'
-include { emmtyper                      } from '../modules/nf-core/emmtyper/main.nf'
-include { mlst                          } from '../modules/nf-core/mlst/main.nf'
-include { mask_polymorph_assembly       } from '../modules/local/mask/main.nf'
-include { sccmec                        } from '../modules/nf-core/sccmec/main.nf'
-include { serotypefinder                } from '../modules/nf-core/serotypefinder/main.nf'
-include { shigapass                     } from '../modules/nf-core/shigapass/main.nf'
-include { spatyper                      } from '../modules/nf-core/spatyper/main.nf'
+include { bwa_index                                 } from '../modules/nf-core/bwa/main.nf'
+include { bwa_mem as bwa_mem_assembly               } from '../modules/nf-core/bwa/main.nf'
+include { chewbbaca_allelecall                      } from '../modules/nf-core/chewbbaca/main.nf'
+include { chewbbaca_split_results                   } from '../modules/local/chewbbaca/split/main.nf'
+include { emmtyper                                  } from '../modules/nf-core/emmtyper/main.nf'
+include { freebayes                                 } from '../modules/nf-core/freebayes/main.nf'
+include { minimap2_align as minimap2_align_assembly } from '../modules/nf-core/minimap2/main.nf'
+include { minimap2_index                            } from '../modules/nf-core/minimap2/main.nf'
+include { mlst                                      } from '../modules/nf-core/mlst/main.nf'
+include { mask_polymorph_assembly                   } from '../modules/local/mask/main.nf'
+include { samtools_index as samtools_index_assembly } from '../modules/nf-core/samtools/main.nf'
+include { samtools_sort as samtools_sort_assembly   } from '../modules/nf-core/samtools/main.nf'
+include { sccmec                                    } from '../modules/nf-core/sccmec/main.nf'
+include { serotypefinder                            } from '../modules/nf-core/serotypefinder/main.nf'
+include { shigapass                                 } from '../modules/nf-core/shigapass/main.nf'
+include { spatyper                                  } from '../modules/nf-core/spatyper/main.nf'
 
 workflow CALL_TYPING {
     take:
@@ -23,8 +30,8 @@ workflow CALL_TYPING {
     species
     training_file
     ch_assembly
+    ch_reads
     ch_sample_id
-    ch_vcf
 
     main:
 
@@ -40,7 +47,48 @@ workflow CALL_TYPING {
     }
 
     if ( params.use_masking ) {
-        mask_polymorph_assembly(ch_assembly.join(ch_vcf))
+        // MASKING VARIANT CALLING (against assembly, for cgMLST)
+        bwa_index(ch_assembly)
+        minimap2_index(ch_assembly)
+
+        ch_reads
+            .join(bwa_index.out.index)
+            .multiMap { id, reads, index ->
+                reads: tuple(id, reads)
+                index: index
+            }
+            .set{ ch_bwa_mem_assembly_map }
+        bwa_mem_assembly(ch_bwa_mem_assembly_map.reads, ch_bwa_mem_assembly_map.index)
+
+        ch_reads
+            .join(minimap2_index.out.index)
+            .multiMap { id, reads, index ->
+                reads: tuple(id, reads)
+                index: index
+            }
+            .set{ ch_minimap2_align_assembly_map }
+        minimap2_align_assembly(ch_minimap2_align_assembly_map.reads, ch_minimap2_align_assembly_map.index)
+        samtools_sort_assembly(minimap2_align_assembly.out.sam)
+
+        bwa_mem_assembly.out.bam.mix(samtools_sort_assembly.out.bam).set{ ch_assembly_bam }
+
+        samtools_index_assembly(ch_assembly_bam)
+
+        ch_assembly_bam
+            .join(samtools_index_assembly.out.bai)
+            .set{ ch_assembly_bam_bai }
+
+        freebayes(ch_assembly.join(ch_assembly_bam_bai)).vcf.set{ ch_polymorph_vcf }
+
+        ch_versions = ch_versions.mix(bwa_index.out.versions)
+        ch_versions = ch_versions.mix(bwa_mem_assembly.out.versions)
+        ch_versions = ch_versions.mix(freebayes.out.versions)
+        ch_versions = ch_versions.mix(minimap2_align_assembly.out.versions)
+        ch_versions = ch_versions.mix(minimap2_index.out.versions)
+        ch_versions = ch_versions.mix(samtools_index_assembly.out.versions)
+        ch_versions = ch_versions.mix(samtools_sort_assembly.out.versions)
+
+        mask_polymorph_assembly(ch_assembly.join(ch_polymorph_vcf))
 
         mask_polymorph_assembly.out.fasta
             .multiMap { sample_id, fasta ->

--- a/subworkflows/variant_calling.nf
+++ b/subworkflows/variant_calling.nf
@@ -2,73 +2,29 @@
 
 nextflow.enable.dsl=2
 
-include { bwa_index                                 } from '../modules/nf-core/bwa/main.nf'
-include { bwa_mem as bwa_mem_assembly               } from '../modules/nf-core/bwa/main.nf'
-include { freebayes                                 } from '../modules/nf-core/freebayes/main.nf'
-include { minimap2_align as minimap2_align_assembly } from '../modules/nf-core/minimap2/main.nf'       
-include { minimap2_index                            } from '../modules/nf-core/minimap2/main.nf'       
-include { samtools_index as samtools_index_assembly } from '../modules/nf-core/samtools/main.nf'
-include { samtools_sort as samtools_sort_assembly   } from '../modules/nf-core/samtools/main.nf'
+include { freebayes } from '../modules/nf-core/freebayes/main.nf'
 
 workflow CALL_VARIANT_CALLING {
     take:
-    ch_assembly
-    ch_reads
-    ch_sample_id
+    ch_ref_bam
+    ch_ref_bai
+    reference_genome
 
     main:
 
     ch_versions = Channel.empty()
 
-    if ( params.use_masking ) {
-        // VARIANT CALLING
-        bwa_index(ch_assembly)
-        minimap2_index(ch_assembly)
+    // VARIANT CALLING against reference genome (for reporting / postprocessing)
+    ch_ref_bam
+        .join(ch_ref_bai)
+        .set{ ch_ref_bam_bai }
 
-        // create input map channels for bwa on assembly
-        ch_reads
-            .join(bwa_index.out.index)
-            .multiMap { id, reads, index -> 
-                reads: tuple(id, reads)
-                index: index
-            }
-            .set{ ch_bwa_mem_assembly_map }
-        bwa_mem_assembly(ch_bwa_mem_assembly_map.reads, ch_bwa_mem_assembly_map.index)
+    freebayes(
+        ch_ref_bam_bai.map { id, bam, bai -> tuple(id, reference_genome, bam, bai) }
+    )
+    ch_vcf = freebayes.out.vcf
 
-        // create input map channels for minimap2 on assembly
-        ch_reads
-            .join(minimap2_index.out.index)
-            .multiMap { id, reads, index -> 
-                reads: tuple(id, reads)
-                index: index
-            }
-            .set{ ch_minimap2_align_assembly_map }
-        minimap2_align_assembly(ch_minimap2_align_assembly_map.reads, ch_minimap2_align_assembly_map.index)
-        samtools_sort_assembly(minimap2_align_assembly.out.sam)
-
-        bwa_mem_assembly.out.bam.mix(samtools_sort_assembly.out.bam).set{ ch_bam }
-
-        samtools_index_assembly(ch_bam)
-
-        // construct freebayes input channels
-        ch_bam
-            .join(samtools_index_assembly.out.bai)
-            .set{ ch_bam_bai }
-
-        freebayes(ch_assembly.join(ch_bam_bai))
-        ch_vcf = freebayes.out.vcf
-
-        ch_versions = ch_versions.mix(bwa_index.out.versions)
-        ch_versions = ch_versions.mix(bwa_mem_assembly.out.versions)
-        ch_versions = ch_versions.mix(freebayes.out.versions)
-        ch_versions = ch_versions.mix(minimap2_align_assembly.out.versions)
-        ch_versions = ch_versions.mix(minimap2_index.out.versions)
-        ch_versions = ch_versions.mix(samtools_index_assembly.out.versions)
-        ch_versions = ch_versions.mix(samtools_sort_assembly.out.versions)
-
-    } else {
-      ch_sample_id.set{ ch_vcf }
-    }
+    ch_versions = ch_versions.mix(freebayes.out.versions)
 
     emit:
     vcf         = ch_vcf                // channel: [ val(meta), path(vcf) ]

--- a/subworkflows/variant_calling.nf
+++ b/subworkflows/variant_calling.nf
@@ -2,6 +2,7 @@
 
 nextflow.enable.dsl=2
 
+include { clair3    } from '../modules/nf-core/clair3/main.nf'
 include { freebayes } from '../modules/nf-core/freebayes/main.nf'
 
 workflow CALL_VARIANT_CALLING {
@@ -9,24 +10,30 @@ workflow CALL_VARIANT_CALLING {
     ch_ref_bam
     ch_ref_bai
     reference_genome
+    reference_genome_faidx
+    clair3_model
 
     main:
 
     ch_versions = Channel.empty()
 
-    // VARIANT CALLING against reference genome (for reporting / postprocessing)
     ch_ref_bam
         .join(ch_ref_bai)
         .set{ ch_ref_bam_bai }
 
-    freebayes(
-        ch_ref_bam_bai.map { id, bam, bai -> tuple(id, reference_genome, bam, bai) }
-    )
-    ch_vcf = freebayes.out.vcf
-
-    ch_versions = ch_versions.mix(freebayes.out.versions)
+    if ( params.platform == "nanopore" ) {
+        clair3(ch_ref_bam_bai, reference_genome, reference_genome_faidx, clair3_model)
+        ch_vcf = clair3.out.vcf
+        ch_versions = ch_versions.mix(clair3.out.versions)
+    } else {
+        freebayes(
+            ch_ref_bam_bai.map { id, bam, bai -> tuple(id, reference_genome, bam, bai) }
+        )
+        ch_vcf = freebayes.out.vcf
+        ch_versions = ch_versions.mix(freebayes.out.versions)
+    }
 
     emit:
-    vcf         = ch_vcf                // channel: [ val(meta), path(vcf) ]
-    versions    = ch_versions           // channel: [ versions.yml ]
+    vcf         = ch_vcf        // channel: [ val(meta), path(vcf) ]
+    versions    = ch_versions   // channel: [ versions.yml ]
 }

--- a/subworkflows/variant_calling.nf
+++ b/subworkflows/variant_calling.nf
@@ -2,8 +2,8 @@
 
 nextflow.enable.dsl=2
 
-include { clair3    } from '../modules/nf-core/clair3/main.nf'
-include { freebayes } from '../modules/nf-core/freebayes/main.nf'
+include { clair3 as clair3_ref       } from '../modules/nf-core/clair3/main.nf'
+include { freebayes as freebayes_ref } from '../modules/nf-core/freebayes/main.nf'
 
 workflow CALL_VARIANT_CALLING {
     take:
@@ -22,15 +22,15 @@ workflow CALL_VARIANT_CALLING {
         .set{ ch_ref_bam_bai }
 
     if ( params.platform == "nanopore" ) {
-        clair3(ch_ref_bam_bai, reference_genome, reference_genome_faidx, clair3_model)
-        ch_vcf = clair3.out.vcf
-        ch_versions = ch_versions.mix(clair3.out.versions)
+        clair3_ref(ch_ref_bam_bai, reference_genome, reference_genome_faidx, clair3_model)
+        ch_vcf = clair3_ref.out.vcf
+        ch_versions = ch_versions.mix(clair3_ref.out.versions)
     } else {
-        freebayes(
+        freebayes_ref(
             ch_ref_bam_bai.map { id, bam, bai -> tuple(id, reference_genome, bam, bai) }
         )
-        ch_vcf = freebayes.out.vcf
-        ch_versions = ch_versions.mix(freebayes.out.versions)
+        ch_vcf = freebayes_ref.out.vcf
+        ch_versions = ch_versions.mix(freebayes_ref.out.versions)
     }
 
     emit:

--- a/workflows/bacterial_general.nf
+++ b/workflows/bacterial_general.nf
@@ -84,9 +84,9 @@ workflow CALL_BACTERIAL_GENERAL {
     )
 
     CALL_VARIANT_CALLING (
-        CALL_ASSEMBLY.out.assembly,
-        CALL_PREPROCESSING.out.reads,
-        CALL_PREPROCESSING.out.sample_id
+        CALL_QUALITY_CONTROL.out.bam,
+        CALL_QUALITY_CONTROL.out.bai,
+        reference_genome
     )
 
     CALL_TYPING (
@@ -99,8 +99,8 @@ workflow CALL_BACTERIAL_GENERAL {
         species,
         training_file,
         CALL_ASSEMBLY.out.assembly,
-        CALL_PREPROCESSING.out.sample_id,
-        CALL_VARIANT_CALLING.out.vcf
+        CALL_PREPROCESSING.out.reads,
+        CALL_PREPROCESSING.out.sample_id
     )
 
     CALL_SCREENING (

--- a/workflows/bacterial_general.nf
+++ b/workflows/bacterial_general.nf
@@ -18,6 +18,7 @@ workflow CALL_BACTERIAL_GENERAL {
     // load references 
     reference_genome        = params.reference_genome       ? file(params.reference_genome, checkIfExists: true)        : Channel.value([])
     reference_genome_dir    = params.reference_genome       ? file(reference_genome.getParent(), checkIfExists: true)   : Channel.value([])
+    reference_genome_faidx  = params.reference_genome       ? file(params.reference_genome + ".fai", checkIfExists: true) : Channel.value([])
     reference_genome_gff    = params.reference_genome_gff   ? file(params.reference_genome_gff, checkIfExists: true)    : Channel.value([])
     reference_genome_idx    = params.reference_genome_idx   ? file(params.reference_genome_idx, checkIfExists: true)    : Channel.value([])
 
@@ -41,6 +42,7 @@ workflow CALL_BACTERIAL_GENERAL {
 
     // schemas and values
     assay                   = params.assay                  ? params.assay                                              : Channel.value([])
+    clair3_model            = params.clair3_model           ? params.clair3_model                                       : Channel.value([])
     hostile_dir             = params.hostile_dir            ? file(params.hostile_dir, checkIfExists: true)             : Channel.value([])
     hostile_idx             = params.hostile_idx            ? params.hostile_idx                                        : Channel.value([])
     mlst_scheme             = params.mlst_scheme            ? params.mlst_scheme                                        : Channel.value([])
@@ -86,7 +88,9 @@ workflow CALL_BACTERIAL_GENERAL {
     CALL_VARIANT_CALLING (
         CALL_QUALITY_CONTROL.out.bam,
         CALL_QUALITY_CONTROL.out.bai,
-        reference_genome
+        reference_genome,
+        reference_genome_faidx,
+        clair3_model
     )
 
     CALL_TYPING (

--- a/workflows/bacterial_general.nf
+++ b/workflows/bacterial_general.nf
@@ -18,7 +18,7 @@ workflow CALL_BACTERIAL_GENERAL {
     // load references 
     reference_genome        = params.reference_genome       ? file(params.reference_genome, checkIfExists: true)        : Channel.value([])
     reference_genome_dir    = params.reference_genome       ? file(reference_genome.getParent(), checkIfExists: true)   : Channel.value([])
-    reference_genome_faidx  = params.reference_genome       ? file(params.reference_genome + ".fai", checkIfExists: true) : Channel.value([])
+    reference_genome_faidx  = params.reference_genome_fai   ? file(params.reference_genome_fai, checkIfExists: true)      : Channel.value([])
     reference_genome_gff    = params.reference_genome_gff   ? file(params.reference_genome_gff, checkIfExists: true)    : Channel.value([])
     reference_genome_idx    = params.reference_genome_idx   ? file(params.reference_genome_idx, checkIfExists: true)    : Channel.value([])
 
@@ -95,6 +95,7 @@ workflow CALL_BACTERIAL_GENERAL {
 
     CALL_TYPING (
         chewbbaca_db,
+        clair3_model,
         mlst_blast_db,
         mlst_scheme,
         pubmlst_db,


### PR DESCRIPTION
# Description

This is the final code changes before v1.3.0 release. Perhaps there will be some updating of jasentool and bonsai-prp versions. If nanopore saureus passes I will merge.

_Summary of the changes made:_
- Added `clair3` (v2.0.0, `docker://hkubal/clair3:v2.0.0`) as the nanopore variant caller in `subworkflows/variant_calling.nf`, replacing freebayes for the nanopore platform; default model `r1041_e82_400bps_sup_v430_bacteria_finetuned`
- Moved variant calling for masking polymorphisms before cgmlst typing to `subworkflows/typing.nf`

## Primary function of PR
- [x] Major functionality improvement / New type of analysis

# Testing
- [x] Nanopore saureus test (@Emkago)
- [x] Nanopore saureus test `-stub-run` (@ryanjameskennedy)